### PR TITLE
Added support for OSM/OSM.bz2 to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Generate random points with: 
 
     $ python gen_points.py filename num_points
 
-filename can be file with pbf or osm extension
+filename can be file with pbf, osm or osm.bz2 extension
 
 Generate a bunch of requests with: 
 


### PR DESCRIPTION
Since [Imposm parser](http://imposm.org/docs/imposm.parser/1.0.5/) supports osm and osm.bz2 in addition to PBF I added this information to Readme.
