### PR TITLE
Add datetime params and fixed default time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM node:6
+MAINTAINER Digitransit version: 0.1
+
+RUN mkdir -p /opt/OTPQA
+
+WORKDIR /opt/OTPQA
+
+ENV TARGET_HOST dev-api.digitransit.fi
+
+ADD . /opt/OTPQA
+
+RUN apt-get update && \
+  apt-get install -y python-simplejson python-scipy curl
+
+RUN curl --silent --show-error --retry 5 https://bootstrap.pypa.io/get-pip.py | python
+
+RUN pip install grequests
+
+RUN cd data && \
+  npm install node-fetch && \
+  node parse_places.js | tee ../endpoints_custom_hsl
+
+RUN python gen_requests.py 
+
+EXPOSE 8000
+
+CMD python otpprofiler.py ${TARGET_HOST} && \
+  python hreport.py run_summary.*json > report.html && \
+  python -m SimpleHTTPServer

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,9 @@ RUN apt-get update && \
 RUN pip install grequests
 
 RUN cd data && \
+  echo "name,lat,lon" > ../endpoints_custom_hsl.csv && \
   npm install node-fetch && \
-  node parse_places.js | tee ../endpoints_custom_hsl.csv
+  node parse_places.js | tee -a ../endpoints_custom_hsl.csv
 
 RUN python gen_requests.py
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,7 @@ ENV TARGET_HOST dev-api.digitransit.fi
 ADD . /opt/OTPQA
 
 RUN apt-get update && \
-  apt-get install -y python-simplejson python-scipy curl
-
-RUN curl --silent --show-error --retry 5 https://bootstrap.pypa.io/get-pip.py | python
+  apt-get install -y python-simplejson python-scipy python-pip curl
 
 RUN pip install grequests
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,9 @@ RUN pip install grequests
 
 RUN cd data && \
   npm install node-fetch && \
-  node parse_places.js | tee ../endpoints_custom_hsl
+  node parse_places.js | tee ../endpoints_custom_hsl.csv
 
-RUN python gen_requests.py 
+RUN python gen_requests.py
 
 EXPOSE 8000
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ OTPQA
 2. Run tests against host `docker run -p8000:8000 -e TARGET_HOST=dev-api.digitransit.fi hsldevcom/otpqa`
 3. Check results: http://localhost:8000/report.html
 
+
 ## Original OTPQA docs
 
 Keep track of changes in OTP performance as development progresses, and catch breaking changes to input data sets by observing changes in routing results.
@@ -45,3 +46,19 @@ To generate a report run
 To generate an HTML report, run
 
     $ python hreport.py f1 [fn2 [fn3 ...]] > report.html
+
+
+## Routing performance and regression detection
+
+Generate a benchmark file:
+
+    $ python otpprofiler.py hostname
+
+When data or OTP changes, generate a test file:
+
+    $ python otpprofiler.py hostname
+
+Then run comparison:
+
+    $ python compare.py benchmark_profile.json new_profile.json
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 OTPQA
 =====
 
+## Docker quickstart
+
+1. Build image: `docker build -t hsldevcom/otpqa .`
+2. Run tests against host `docker run -p8000:8000 -e TARGET_HOST=dev-api.digitransit.fi hsldevcom/otpqa`
+3. Check results: http://localhost:8000/results.html
+
+## Original OTPQA docs
+
 Keep track of changes in OTP performance as development progresses, and catch breaking changes to input data sets by observing changes in routing results.
 
 You will need Python and some Python libraries. For the libraries, on a Debian based system like Ubuntu you can run:
@@ -26,7 +34,7 @@ It takes no arguments, assumes the presence of endpoints_random.csv and endpoint
 Then run the profiler with 
 
     $ python otpprofiler.py hostname
-    
+
 That will generate run_summary.TIMESTAMP.json and full_itins.TIMESTAMP.json
 That one can do with what one pleases.
 
@@ -37,4 +45,3 @@ To generate a report run
 To generate an HTML report, run
 
     $ python hreport.py f1 [fn2 [fn3 ...]] > report.html
-

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ OTPQA
 
 1. Build image: `docker build -t hsldevcom/otpqa .`
 2. Run tests against host `docker run -p8000:8000 -e TARGET_HOST=dev-api.digitransit.fi hsldevcom/otpqa`
-3. Check results: http://localhost:8000/results.html
+3. Check results: http://localhost:8000/report.html
 
 ## Original OTPQA docs
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ OTPQA
 
 Keep track of changes in OTP performance as development progresses, and catch breaking changes to input data sets by observing changes in routing results.
 
-You will need Python and some Python libraries. For the libraries, on a Debian based system like Ubuntu you can run:
+You will need Python (2.x) and some Python libraries. For the libraries, on a Debian based system like Ubuntu you can run:
 
 `$ sudo apt-get install python-simplejson python-scipy`
 
@@ -26,7 +26,7 @@ It takes no arguments, assumes the presence of endpoints_random.csv and endpoint
 Then run the profiler with 
 
     $ python otpprofiler.py hostname
-    
+
 That will generate run_summary.TIMESTAMP.json and full_itins.TIMESTAMP.json
 That one can do with what one pleases.
 
@@ -34,7 +34,8 @@ To generate a report run
 
     $ python report.py filename1.json filename2.json
 
+Where a file name corresponds to a run_summary file created earlier
+
 To generate an HTML report, run
 
     $ python hreport.py f1 [fn2 [fn3 ...]] > report.html
-

--- a/compare.py
+++ b/compare.py
@@ -15,7 +15,7 @@ def extractdurations(filename):
         for id_tuple in dataset:
                 response = dataset[id_tuple]
 
-                if len(response["itins"]) == 0:
+                if not "itins" in response or len(response["itins"]) == 0:
                         durations[id_tuple] = -1
                 else:
 			durations[id_tuple] = parsetime( response["itins"][0]["duration"] )
@@ -32,7 +32,7 @@ def main(filenames):
         count = 0
 
 	for id in dur1:
-                if not id in dur1 or not id in dur2:
+                if not id in dur2:
                         print "test data is not comparable"
                         exit()
                 t1 = dur1[id]

--- a/compare.py
+++ b/compare.py
@@ -34,7 +34,8 @@ def main(filenames):
 	for id in dur1:
                 t1 = dur1[id]
                 t2 = dur2[id]
-
+                if t1 != t2:
+                        print "Test %s t1=%d t2=%d"%(id, t1, t2)
                 if t1 < 0 and t2 > 0:
                         fails1+=1
                 elif t1 > 0 and t2 < 0:

--- a/compare.py
+++ b/compare.py
@@ -1,0 +1,66 @@
+import simplejson as json
+
+def parsetime(aa):
+	if aa is None:
+		return None
+
+	return float( aa.split()[0] )
+
+def extractdurations(filename):
+        blob = json.load( open(filename) )
+        dataset = dict( [(response["id_tuple"], response) for response in blob["responses"]] )
+
+        durations = {}
+
+        for id_tuple in dataset:
+                response = dataset[id_tuple]
+
+                if len(response["itins"]) == 0:
+                        durations[id_tuple] = -1
+                else:
+			durations[id_tuple] = parsetime( response["itins"][0]["duration"] )
+        return durations
+
+def main(filenames):
+        dur1 = extractdurations(filenames[0])
+        dur2 = extractdurations(filenames[1])
+
+        fails1 = 0
+        fails2 = 0
+        slower1 = 0
+        slower2 = 0
+        count = 0
+
+	for id in dur1:
+                t1 = dur1[id]
+                t2 = dur2[id]
+
+                if t1 < 0 and t2 > 0:
+                        fails1+=1
+                elif t1 > 0 and t2 < 0:
+                        fails2+=1
+                elif t1 > t2:
+                        slower1+=1
+                elif t1 < t2:
+                        slower2+=1
+                count+=1
+
+
+        print "Test count: %d"%count
+        print "Routings that failed only in %s: %d"%(filenames[0], fails1)
+        print "Routings that failed only in %s: %d"%(filenames[1], fails2)
+        print "Routes that are slower in %s: %d"%(filenames[0], slower1)
+        print "Routes that are slower in %s: %d"%(filenames[1], slower2)
+
+        print "Regressions: %d"%(fails2 + slower2)
+        print "Comparison rate:"
+        print (float(count + fails1 - fails2 + slower1 - slower2)/float(count))
+
+if __name__=="__main__":
+	import sys
+
+	if len(sys.argv)!=3:
+		print "usage: cmd fn1 fn2]"
+		exit()
+	main(sys.argv[1:])
+

--- a/compare.py
+++ b/compare.py
@@ -32,6 +32,9 @@ def main(filenames):
         count = 0
 
 	for id in dur1:
+                if not id in dur1 or not id in dur2:
+                        print "test data is not comparable"
+                        exit()
                 t1 = dur1[id]
                 t2 = dur2[id]
                 if t1 != t2:

--- a/data/parse_places.js
+++ b/data/parse_places.js
@@ -10,7 +10,7 @@ const TEMPLATE = 'http://dev-api.digitransit.fi/geocoding/v1/search?boundary.rec
 const agent = new http.Agent({
   keepAlive: true,
   keepAliveMsecs: 60000,
-  maxSockets: 50
+  maxSockets: 2
 });
 
 readline.createInterface({

--- a/data/parse_places.js
+++ b/data/parse_places.js
@@ -1,0 +1,30 @@
+const { createReadStream } = require('fs')
+const readline = require('readline')
+const http = require('http')
+const fetch = require('node-fetch')
+
+//console.log('name,lat,lon')
+
+const TEMPLATE = 'http://dev-api.digitransit.fi/geocoding/v1/search?boundary.rect.min_lat=59.9&boundary.rect.max_lat=60.45&boundary.rect.min_lon=24.3&boundary.rect.max_lon=25.5&text='
+
+const agent = new http.Agent({
+  keepAlive: true,
+  keepAliveMsecs: 60000,
+  maxSockets: 50
+});
+
+readline.createInterface({
+  input: createReadStream('reittiopas-geocoded-places-n-100.txt')
+}).on('line', line =>
+  fetch(`${TEMPLATE}${encodeURIComponent(line.split(/\s+\d+\s+/)[1])}`, {agent: agent})
+    .then(res => {
+      if (res.status === 200)
+        return res.json()
+        res.text().then(text => console.warn(text))
+    })
+    .then(data =>
+      console.log(`"${data.features[0].properties.label}",${data.features[0].geometry.coordinates[1]},${data.features[0].geometry.coordinates[0]}`)
+      //data.features[0].properties.label.toLowerCase() === line.split(/\s+\d+\s+/)[1].toLowerCase() || console.log(line.split(/\s+\d+\s+/)[1] + " => " + data.features[0].properties.label)
+    )
+    .catch((err) => console.warn(err))
+)

--- a/data/reittiopas-geocoded-places-n-100.txt
+++ b/data/reittiopas-geocoded-places-n-100.txt
@@ -1,0 +1,2203 @@
+    100 Herttoniemi(M), Helsinki
+    100 Hämeentie 28, Helsinki
+    100 Hämeentie 81, Helsinki
+    100 Isonvillasaarentie 1, Helsinki
+    100 Jönsaksentie 6, Vantaa
+    100 Karakalliontie 14, Espoo
+    100 Katontekijänkuja 1, Helsinki
+    100 Mattilanpuisto, Kerava
+    100 Mäntytie 1, Helsinki
+    100 Pengerkatu 21, Helsinki
+    100 Pengerkatu 22, Helsinki
+    100 Pihkatie 5, Helsinki
+    100 Pitäjänmäentie 13, Helsinki
+    100 Porvoonkatu 25, Helsinki
+    100 Pähkinätie 3, Vantaa
+    100 Roihuvuorentie 30, Helsinki
+    100 Ruotsinpiha 2, Vantaa
+    100 Samis, Kauniainen
+    100 Scandic Park, Helsinki
+    100 Sellosali, Espoo
+    100 Sörnäistenkatu 1, Helsinki
+    100 Taimistontie 1, Helsinki
+    100 Tehtaankatu 25, Helsinki
+    100 Teknikontie 7, Vantaa
+    100 Vaakatie 1, Helsinki
+    100 Vaasankatu 9, Helsinki
+    101 Alakiventie 1, Helsinki
+    101 Hitsaajankatu 9, Helsinki
+    101 Huopalahdentie 24, Helsinki
+    101 Huopalahdentie 3, Helsinki
+    101 Hämeentie 95, Helsinki
+    101 Ilmalantori 1, Helsinki
+    101 Itsehallintokuja 6, Espoo
+    101 Itäviitta 1, Espoo
+    101 Kaarlenkatu 15, Helsinki
+    101 Kaisaniemenkatu 3, Helsinki
+    101 Kivikko, Helsinki
+    101 Klippinkitie 1, Espoo
+    101 Koskelantie 23, Helsinki
+    101 Koudantie 2, Helsinki
+    101 Kuortaneenkatu 7, Helsinki
+    101 Kuunkehrä 1, Espoo
+    101 Lauttasaarentie 32, Helsinki
+    101 Maasälväntie 16, Helsinki
+    101 Neljäs Linja 26, Helsinki
+    101 Niittykummuntie 6, Espoo
+    101 Opettajantie 3, Espoo
+    101 Perhonkatu 1, Helsinki
+    101 Pietarinkatu 1, Helsinki
+    101 Pohjois-Tapiolan lukio, Espoo
+    101 Pyhtäänkorventie 21, Vantaa
+    101 Riiantie 1, Espoo
+    101 Riistavuorenkuja 8, Helsinki
+    101 Rosendalinrinki 1, Vantaa
+    101 Sammalkalliontie 6, Espoo
+    101 Sibelius-lukio, Helsinki
+    101 Sturenkatu 26, Helsinki
+    101 Säterinkatu 2, Vantaa
+    101 Taavetti Laitisen katu 1, Helsinki
+    101 Takkatie 7, Helsinki
+    101 Talonpojantie 25, Helsinki
+    101 Talvelantie 4, Helsinki
+    101 Tammistonkatu 27, Vantaa
+    101 Vaijeritie 1, Vantaa
+    101 Vallilan varikko, Helsinki
+    101 Yrjönkatu 21, Helsinki
+    102 Alppila, Helsinki
+    102 Apollonkatu, Helsinki
+    102 Arinatie 20, Vantaa
+    102 Backåkersvägen 19, Helsinki
+    102 Brinkinmäentie 1, Espoo
+    102 Bulevardi 40, Helsinki
+    102 Espoontie 25, Espoo
+    102 Hagelstamintie 20, Vantaa
+    102 Hietaniemenkatu 1, Helsinki
+    102 Huopalahdentie 1, Helsinki
+    102 Hämeentie 26, Helsinki
+    102 Hämeentie 70, Helsinki
+    102 Karapellontie 11, Espoo
+    102 Kaupunginteatteri, Helsinki
+    102 Kirstintie 17, Espoo
+    102 Kutomotie 6, Helsinki
+    102 Malminkartanontie 1, Helsinki
+    102 Mestarintie 5, Vantaa
+    102 Mustialankatu 1, Helsinki
+    102 Näyttelijäntie, Helsinki
+    102 Reiherintie 7, Helsinki
+    102 Stoa, Helsinki
+    102 Tenholantie 1, Helsinki
+    102 Töölönkatu 27, Helsinki
+    102 Unioninkatu 39, Helsinki
+    102 Vanamonkuja 1, Vantaa
+    102 Vanha Yrttimaantie 22, Helsinki
+    102 Vattuniemenkatu 16, Helsinki
+    102 Veromäen koulu, Vantaa
+    102 Vieraskuja 1, Espoo
+    103 Fredrikinkatu 48, Helsinki
+    103 Heikinlaaksontie 1, Helsinki
+    103 Hirsalantie 11, Kirkkonummi
+    103 Hirsipadontie 5, Helsinki
+    103 Hämeentie 36, Helsinki
+    103 Kaisaniemenkatu 2, Helsinki
+    103 Karjalankatu 2, Helsinki
+    103 Katajanokanlaituri 1, Helsinki
+    103 Katariina Saksilaisen katu 1, Helsinki
+    103 Kirjurinkuja 1, Espoo
+    103 Kluuvikatu 1, Helsinki
+    103 Koivu-mankkaan tie 5, Espoo
+    103 Kutomotie 12, Helsinki
+    103 Käpyläntie 4, Helsinki
+    103 Linnoitustie 6, Espoo
+    103 Makasiiniterminaali, Helsingfors
+    103 Mannerheimintie 22, Helsinki
+    103 Mannerheimintie 47, Helsinki
+    103 Metsänhoitajankatu 1, Helsinki
+    103 Nuolikuja 6, Vantaa
+    103 Otaranta 6, Espoo
+    103 Pasilanraitio 12, Helsinki
+    103 Porslahdentie 1, Helsinki
+    103 Pursimiehenkatu 25, Helsinki
+    103 Siltasaarenkatu 15, Helsinki
+    103 Siltavoudintie 1, Helsinki
+    103 Simonkallion koulu, Vantaa
+    103 Sotungintie 19, Vantaa
+    103 Valimotie 16, Helsinki
+    103 Vantaanpuisto, Vantaa
+    103 Vattuniemenranta 2, Helsinki
+    103 Vuorikatu 14, Helsinki
+    104 Aalto 6, Espoo
+    104 Asema-aukio 2, Helsinki
+    104 Hagelstamintie 27, Vantaa
+    104 Helsinginkatu 14, Helsinki
+    104 Horsmakuja 4, Vantaa
+    104 Kaivosrinteenkuja 2, Vantaa
+    104 Kamreerintie 2, Espoo
+    104 Kansallisteatteri, Helsinki
+    104 Kaskenkaatajantie 1, Espoo
+    104 Korppaanmäentie 17, Helsinki
+    104 Kurkisuontie 12, Helsinki
+    104 Linnatullinkatu 1, Espoo
+    104 Länsisatamankatu 16, Helsinki
+    104 Maununnevantie 1, Helsinki
+    104 Mechelininkatu 15, Helsinki
+    104 Myyrmäentie 2, Vantaa
+    104 Niittymaantie 1, Espoo
+    104 Osmontie 34, Helsinki
+    104 Pikku Satamakatu 3, Helsinki
+    104 Pohjantori, Espoo
+    104 Tanhuantie 1, Helsinki
+    104 Toinen Linja 10, Helsinki
+    104 Töyrytie 6, Helsinki
+    104 Untamontie 10, Helsinki
+    104 Untamontie 15, Helsinki
+    104 Urheilupuistontie 2, Espoo
+    104 Vyökatu 1, Helsinki
+    104 Vääksyntie 4, Helsinki
+    104 Wallininkuja 3, Helsinki
+    104 Ylistörmä 5, Espoo
+    105 EMMA Espoon modernin taiteen museo, Espoo
+    105 Haapaniemenkatu 12, Helsinki
+    105 Jämeräntaival 3, Espoo
+    105 Keijumäki 1, Espoo
+    105 Kilo Park and Ride, Espoo
+    105 Kiltakuja 1, Espoo
+    105 Kuurinniitty, Espoo
+    105 Kuusitie 11, Helsinki
+    105 Käskynhaltijantie 14, Helsinki
+    105 Läkkisepänkuja 8, Helsinki
+    105 Malmin Kauppatie 8, Helsinki
+    105 Munkkiniemen puistotie 25, Helsinki
+    105 Nuijavuori 1, Espoo
+    105 Otavantie 1, Helsinki
+    105 Pallomylly, Helsinki
+    105 Pasilan kirjasto, Helsinki
+    105 Pukinkuja 2, Helsinki
+    105 Runeberginkatu 32, Helsinki
+    105 Sampsantie 50, Helsinki
+    105 Saunakallio, -
+    105 Soukantie 16, Espoo
+    105 Talttakuja 1, Vantaa
+    105 Tapiolan terveysasema, Espoo
+    105 Teknillinen korkeakoulu, Espoo
+    105 Tukholmankatu 2, Helsinki
+    105 Urheilukatu 9, Helsinki
+    106 Allergiatalo, Helsinki
+    106 Arabiankatu 12, Helsinki
+    106 Arabiankatu 6, Helsinki
+    106 Ensi Linja 2, Helsinki
+    106 Haapaniemenkatu 11, Helsinki
+    106 Isokaari 9, Helsinki
+    106 Isonnevantie 28, Helsinki
+    106 Juvanpuro 1, Espoo
+    106 Kaikukatu 2, Helsinki
+    106 Kaskilaaksontie 1, Espoo
+    106 Kaupintie 11, Helsinki
+    106 Kivikonkaari 49, Helsinki
+    106 Krakankuja 2, Vantaa
+    106 Liuskekuja 1, Helsinki
+    106 Länsisatamankatu 23, Helsinki
+    106 Läntinen Papinkatu 2, Helsinki
+    106 Mannerheimintie 81, Helsinki
+    106 Merenkulkijankatu 1, Espoo
+    106 Mäkitorpantie 30, Helsinki
+    106 Nelikkokuja 1, Espoo
+    106 Paciuksenkatu 29, Helsinki
+    106 Postipuuntie 10, Espoo
+    106 Siltasaarenkatu 13, Helsinki
+    106 Snellmaninkatu 1, Helsinki
+    106 Vaisalantie 8, Espoo
+    106 Vallikatu 1, Espoo
+    106 Vanha Nurmijärventie 62, Vantaa
+    106 Vanha Viertotie 22, Helsinki
+    106 Vattuniemen puistotie 1, Helsinki
+    106 Vesikuja 8, Helsinki
+    106 Westendintie 99, Espoo
+    107 Alppikatu 9, Helsinki
+    107 Annankatu 18, Helsinki
+    107 Erottajankatu 1, Helsinki
+    107 Eteläinen Rautatiekatu 2, Helsinki
+    107 Hansakallio 2, Espoo
+    107 Hämeentie 44, Helsinki
+    107 Hämeentie 67, Helsinki
+    107 Juustenintie 1, Helsinki
+    107 Kala-maija 3, Espoo
+    107 Kalevankatu 8, Helsinki
+    107 Kiviteltankatu 1, Helsinki
+    107 Käskynhaltijantie 11, Helsinki
+    107 Käskynhaltijantie 1, Helsinki
+    107 Linnoitustie 9, Espoo
+    107 Maapallonkatu 8, Espoo
+    107 Piilipuuntie 7, Espoo
+    107 Pikku-Huopalahti, Helsinki
+    107 Pohjantie 2, Espoo
+    107 Rasinkatu 4, Vantaa
+    107 Tammihaantie 2, Espoo
+    107 Tietotie 6, Espoo
+    107 Vilppulantie 1, Helsinki
+    108 Fabianinkatu 1, Helsinki
+    108 Huopalahdentie 10, Helsinki
+    108 Huutokonttori, Helsinki
+    108 Jokiniemi, Vantaa
+    108 Järnvägstorget, Helsingfors
+    108 Kerava railway station, Kerava
+    108 Kirkkojärventie 6, Espoo
+    108 Kutomotie 16, Helsinki
+    108 Kuusikkotie 4, Helsinki
+    108 Leenankuja 1, Espoo
+    108 Majurinkulma 1, Espoo
+    108 Mekaanikonkatu 1, Helsinki
+    108 Mäkelänkatu 54, Helsinki
+    108 Neitsytsaarentie 1, Helsinki
+    108 Pertunpellontie 1, Helsinki
+    108 Rautatieläisenkatu 1, Helsinki
+    108 Ristiaallokonkatu 4, Espoo
+    108 Sakara 2, Helsinki
+    108 Satulamaakarintie 1, Espoo
+    108 Sauvatie 4, Vantaa
+    108 Solnantie 19, Helsinki
+    108 Säterintie 2, Helsinki
+    108 Sörnäisten Rantatie 23, Helsinki
+    108 Taivaskalliontie 1, Helsinki
+    108 Tapanilan erä, Helsinki
+    108 Töölönkatu 3, Helsinki
+    109 Asemakuja 3, Espoo
+    109 Fabianinkatu 7, Helsinki
+    109 Gyldenintie 2, Helsinki
+    109 Helsinginkatu 20, Helsinki
+    109 Hernesaari, Helsinki
+    109 Hämeentie 30, Helsinki
+    109 Itämerenkatu 8, Helsinki
+    109 Katajaharjuntie 1, Helsinki
+    109 Kirstinkatu 4, Helsinki
+    109 Komeetankatu 2, Espoo
+    109 Kuuluttajankatu 1, Helsinki
+    109 Laivalahdenkaari 34, Helsinki
+    109 Lohkopellontie 1, Helsinki
+    109 Lummetie 5, Vantaa
+    109 Maununnevantie 3, Helsinki
+    109 Nihtisilta 4, Espoo
+    109 Olympiakylä, Helsinki
+    109 Piispansilta, Espoo
+    109 Porvoonkatu 19, Helsinki
+    109 Rasinkatu 15, Vantaa
+    109 Runeberginkatu 61, Helsinki
+    109 Tähkätie 4, Helsinki
+    109 Ulvilantie 1, Helsinki
+    109 Unikkotie 3, Helsinki
+    109 Upseerinkatu 3, Espoo
+    110 Adjutantinkatu 8, Espoo
+    110 Heinjoenpolku 2, Espoo
+    110 Helsinki, Helsingfors
+    110 Henttaa, Espoo
+    110 Junkkarinkaari 7, Vantaa
+    110 Lehdeskuja 1, Espoo
+    110 Munkkiniemen puistotie 17, Helsinki
+    110 Postitalo, Helsinki
+    110 Rautalammintie 1, Helsinki
+    110 Ressun lukio, Helsinki
+    110 Satamaradankatu 5, Helsinki
+    110 Suursuonlaita 2, Helsinki
+    110 Trumpettitie 6, Helsinki
+    110 Tuukkalantie 15, Helsinki
+    110 Valimotie, Helsinki
+    110 Äyritie 12, Vantaa
+    111 Erottajankatu 5, Helsinki
+    111 Hiomotie 46, Helsinki
+    111 Hämeentie 34, Helsinki
+    111 Iivisniemenkatu 4, Espoo
+    111 Isonnevantie 1, Helsinki
+    111 Isonniitynkuja 2, Espoo
+    111 Kaivokselantie 8, Vantaa
+    111 Laivalahdenkaari 19, Helsinki
+    111 Leppävaarankatu 1, Espoo
+    111 Maarukankuja 1, Vantaa
+    111 Mannerheimintie 113, Helsinki
+    111 Nuumäki, Espoo
+    111 Näyttelijäntie 16, Helsinki
+    111 Olarinniityntie 4, Espoo
+    111 Otsolahdentie 16, Espoo
+    111 Raiviosuonmäki 3, Vantaa
+    111 Sahaajankatu 20, Helsinki
+    111 Soidinkuja 6, Helsinki
+    111 Tehtaankatu 27, Helsinki
+    111 Tietotie 2, Espoo
+    111 Toivonkatu 1, Helsinki
+    111 Töölön yhteiskoulu, Helsinki
+    111 Vanha Tapanilantie 62, Helsinki
+    111 Viipurinkatu 4, Helsinki
+    111 Viulutie 1, Helsinki
+    111 Vuorenpeikontie 5, Helsinki
+    112 Antaksentie 3, Vantaa
+    112 Castreninkatu 28, Helsinki
+    112 Honkavaarankuja 1, Espoo
+    112 Huokotie 1, Helsinki
+    112 Hämeentie 3, Helsinki
+    112 Kaivokatu 6, Helsinki
+    112 Kastanjakuja 1, Vantaa
+    112 Kielotie 7, Vantaa
+    112 Kivivuorentie 4, Vantaa
+    112 Kluuvikatu 3, Helsinki
+    112 Lokkalantie 14, Helsinki
+    112 Lontoonkatu 9, Helsinki
+    112 Merituulentie 30, Espoo
+    112 Miestentie 2, Espoo
+    112 Museokatu 10, Helsinki
+    112 Mäkelänkatu 30, Helsinki
+    112 Pirkkolan uimahalli, Helsinki
+    112 Porintie 5, Helsinki
+    112 Sokerilinnantie 11, Espoo
+    112 Teknobulevardi 1, Vantaa
+    112 Temppeliaukio Church, Helsinki
+    112 Vanamontie 4, Vantaa
+    112 Viljo Sohkasen katu 1, Vantaa
+    112 Yrjönkatu 18, Helsinki
+    113 Ateneum, Helsinki
+    113 Esikkotie 9, Vantaa
+    113 Everstinkuja 1, Espoo
+    113 Haapaniemistigen 1, Kirkkonummi
+    113 Hakaniemenkatu 7, Helsinki
+    113 Helsinge skola, Vantaa
+    113 Kaanaanpiha 4, Helsinki
+    113 Kaivopuisto, Helsinki
+    113 Karhulantie 2, Helsinki
+    113 Karhutie 1, Kirkkonummi
+    113 Kasöörinkatu 3, Helsinki
+    113 Katajanokanranta 1, Helsinki
+    113 Kirvisenkuja 1, Vantaa
+    113 Kiskottajankuja 1, Espoo
+    113 Konalantie 12, Helsinki
+    113 Kontulankaari 24, Helsinki
+    113 Kruununhaka, Helsinki
+    113 Kuusitie 12, Helsinki
+    113 Laaksolahden urheilukeskus, Espoo
+    113 Lönnrotinkatu 41, Helsinki
+    113 Löydöstie 1, Vantaa
+    113 Mannerheimintie 120, Helsinki
+    113 Mikkelä, Espoo
+    113 Opastinsilta 8, Helsingfors
+    113 Peltokyläntie, Helsinki
+    113 Raikurinne 1, Vantaa
+    113 Sibeliuksenkatu 10, Helsinki
+    113 Siilitie 18, Helsinki
+    113 Unioninkatu 20, Helsinki
+    113 Vanha Turuntie 75, Espoo
+    113 Vanha Viertotie 2, Helsinki
+    113 Yläkiventie 5, Helsinki
+    114 Betonimiehenkuja 3, Espoo
+    114 Gyldenintie 6, Helsinki
+    114 Hakaniemenranta 1, Helsinki
+    114 Hämeentie 124, Helsinki
+    114 Kirstinkatu 2, Helsinki
+    114 Koivuvaarankuja 1, Vantaa
+    114 Kuitinmäen koulu, Espoo
+    114 Liusketie 16, Helsinki
+    114 Maistraatinportti 4, Helsinki
+    114 Matinkartanontie 1, Espoo
+    114 Myllynkivenkuja 4, Vantaa
+    114 Pasilan puistotie 10, Helsinki
+    114 Sepontie 1, Espoo
+    114 Teuvo Pakkalan tie, Helsinki
+    114 Ukonkivenpolku 4, Vantaa
+    114 Ulvilantie 25, Helsinki
+    115 Aamuruskontie 2, Helsinki
+    115 Aleksis Kiven katu 38, Helsinki
+    115 Bulevardi 28, Helsinki
+    115 Bulevardi 6, Helsinki
+    115 Eteläinen Hesperiankatu 22, Helsinki
+    115 Fredrikinkatu 20, Helsinki
+    115 Helsingin medialukio, Helsinki
+    115 Hertaksentie 2, Vantaa
+    115 Katajanokanlaituri 6, Helsingfors
+    115 Kauriintie 4, Helsinki
+    115 Kielotie 21, Vantaa
+    115 Korkeavuorenkatu 1, Helsinki
+    115 Kumpulantie 1, Helsinki
+    115 Kuusisaari, Helsinki
+    115 Myllymatkantie 4, Helsinki
+    115 Nuijamäki 6, Espoo
+    115 Palokunnanmäki 1, Vantaa
+    115 Pronssitie 4, Helsinki
+    115 Rastilantie 5, Helsinki
+    115 Siemenkuja 3, Helsinki
+    115 Takomotie 8, Helsinki
+    115 Väinölänkatu 17, Helsinki
+    116 Aapelinkatu 1, Espoo
+    116 Albertinkatu 25, Helsinki
+    116 Aleksis Kiven katu 52, Helsinki
+    116 Bemböle, Espoo
+    116 Eteläranta 8, Helsinki
+    116 Hevostilantie 1, Espoo
+    116 Hiihtäjäntie 1, Helsinki
+    116 Ilmalankatu 2, Helsinki
+    116 Jakomäentie 8, Helsinki
+    116 Jumbo Shopping Centre, Vantaa
+    116 Kaitaan lukio, Espoo
+    116 Kaivosvoudintie 4, Vantaa
+    116 Keilaranta 10, Espoo
+    116 Keskuskatu 2, Helsingfors
+    116 Kutojantie 4, Espoo
+    116 Kuusitie 4, Helsinki
+    116 Leinikkitie 11, Vantaa
+    116 Maininki 15, Espoo
+    116 Mankkaantie 2, Espoo
+    116 Meriusva 5, Espoo
+    116 Myrskyläntie 22, Helsinki
+    116 Piispanportti 12, Espoo
+    116 Porvoonkatu 14, Helsinki
+    116 Rosendalinkuja 3, Vantaa
+    116 Salmisaarenranta 11, Helsinki
+    116 Sörnäistenkatu 19, Helsinki
+    116 Teuvo Pakkalan tie 1, Helsinki
+    116 Tilanhoitajankaari 8, Helsinki
+    116 Urheilupuistontie 3, Espoo
+    117 Elimäenkatu 5, Helsinki
+    117 Finnoontie 12, Espoo
+    117 Junailijankuja 10, Helsinki
+    117 Kaarlenkatu 11, Helsinki
+    117 Karakalliontie 5, Espoo
+    117 Keilaranta 13, Espoo
+    117 Liusketie 2, Helsinki
+    117 Piispankalliontie 17, Espoo
+    117 Pikku Satamakatu 1, Helsinki
+    117 Pilotti (hotla), Vantaa
+    117 Pitäjänmäentie 14, Helsinki
+    117 Puunhaltijankuja 1, Vantaa
+    117 Suutarila, Helsinki
+    117 Takkatie 1, Helsinki
+    117 Vanha Tapanilantie 1, Helsinki
+    117 Viherlaaksonranta 7, Espoo
+    117 Viikinkaari 4, Helsinki
+    118 Asentajankatu 6, Helsinki
+    118 Bulevardi 7, Helsinki
+    118 Castreninkatu 3, Helsinki
+    118 Haapaniemenkatu 5, Helsinki
+    118 Heureka tiedekeskus, Vantaa
+    118 Itämerenkatu 23, Helsinki
+    118 Kanneltie 8, Helsinki
+    118 Kiviaidankatu 2, Helsinki
+    118 Kivipadontie 4, Helsinki
+    118 Koivuvaarankuja 2, Vantaa
+    118 Käpylänaukio 1, Helsinki
+    118 Laajavuorenkuja 3, Vantaa
+    118 Lehtovuorenkatu 6, Helsinki
+    118 Leinelänkaari 14, Vantaa
+    118 Leppäsuonkatu 9, Helsinki
+    118 Masalan asema, Kirkkonummi
+    118 Mäkelänkatu 13, Helsinki
+    118 Mäkitorpantie 1, Helsinki
+    118 Männikkötie 5, Helsinki
+    118 Nauriskaski, Espoo
+    118 Nervanderinkatu 13, Helsinki
+    118 Petter Wetterin tie 1, Helsinki
+    118 Pirttikorpi 7, Espoo
+    118 Rajatorpantie 41, Vantaa
+    118 Ratatie 11, Vantaa
+    118 Savela, Helsinki
+    118 Sörnäisten Rantatie 22, Helsinki
+    118 Töölönkatu 55, Helsinki
+    119 Eerikinkatu 27, Helsinki
+    119 Harmotie 1, Vantaa
+    119 Helsinginkatu 21, Helsinki
+    119 Hämeentie 6, Helsinki
+    119 Kasarmikatu 21, Helsinki
+    119 Korppaanmäentie 1, Helsinki
+    119 Kotisaarenkatu 3, Helsinki
+    119 Kuntatalo, Helsinki
+    119 Leinikkitie 9, Vantaa
+    119 Lepuski, Espoo
+    119 Martinkeskus, Vantaa
+    119 Niipperin koulu, Espoo
+    120 Elimäenkatu 30, Helsinki
+    120 Erik Palmenin aukio 1, Helsinki
+    120 Hämeentie 54, Helsinki
+    120 Iho- ja allergiasairaala, Helsinki
+    120 Itälahdenkatu 1, Helsinki
+    120 Itämerenkatu 12, Helsinki
+    120 Kaivosrinteentie 2, Vantaa
+    120 Kantelettarentie 8, Helsinki
+    120 Kiviteltankatu 3, Helsinki
+    120 Kontula Park and Ride, Helsinki
+    120 Mankkaankallio 1, Espoo
+    120 Miestentie 9, Espoo
+    120 Nihtisillantie 1, Espoo
+    120 Puolarmetsä, Espoo
+    120 Seulastentie 11, Helsinki
+    120 Siltasaarenkatu 12, Helsinki
+    120 Valimon asema, Helsinki
+    120 Veräjämäki, Helsinki
+    121 Ala-Tikkurila, Helsinki
+    121 Helsinginkatu 28, Helsinki
+    121 Helsinginkatu 2, Helsinki
+    121 Junailijankuja 5, Helsinki
+    121 Kappelitie 6, Espoo
+    121 Koskela, Helsinki
+    121 Koskelantie 39, Helsinki
+    121 Krakantie 2, Vantaa
+    121 Kuunsäde 1, Espoo
+    121 Kyrölä, -
+    121 Kärrynpyöräntie 1, Espoo
+    121 Leiviskätie 1, Helsinki
+    121 Lumikintie 4, Helsinki
+    121 Nelikkotie 8, Espoo
+    121 Pelimannintie 1, Helsinki
+    121 Pitäjänmäentie 1, Helsinki
+    121 Porthaninkatu 9, Helsinki
+    121 Rahakamarinkatu 1, Helsinki
+    121 Rajametsäntie 35, Helsinki
+    121 Risto Rytin tie 33, Helsinki
+    121 Roihuvuorentie 18, Helsinki
+    121 Servin Maijan tie 10, Espoo
+    121 Takomotie 27, Helsinki
+    122 Agronominkatu 26, Helsinki
+    122 Albertinkatu 40, Helsinki
+    122 Alhokuja 8, Helsinki
+    122 Hämeentie 109, Helsinki
+    122 Iivisniementie 1, Espoo
+    122 Järvenpään asema, Kerava
+    122 Kirkkotallintie 1, Kirkkonummi
+    122 Mäkelänkatu, Helsinki
+    122 Pakilantie 8, Helsinki
+    122 Pietari Hannikaisen tie 6, Helsinki
+    122 Puolarinportti 1, Espoo
+    122 Sundsberg, Kirkkonummi
+    122 Suonotkontie 1, Helsinki
+    123 Esterinportti 2, Helsinki
+    123 Helsingin rautatieasema, Helsingfors
+    123 Henrik Lättiläisen katu 1, Helsinki
+    123 Intiankatu 1, Helsinki
+    123 Kaivokatu 10, Helsinki
+    123 Kalevankatu 1, Helsinki
+    123 Kauppakartanonkatu 16, Helsinki
+    123 Lammastie 1, Vantaa
+    123 Lummetie 1, Vantaa
+    123 Mannerheimintie 79, Helsinki
+    123 Maunulan yhteiskoulu, Helsinki
+    123 Mikkolantie 1, Helsinki
+    123 Mäkelänkatu 50, Helsinki
+    123 Otaranta 2, Espoo
+    123 Ramsaynkuja 1, Espoo
+    123 Ratapihantie 1, Helsinki
+    123 Sturenkatu 37, Helsinki
+    123 Vanha Viertotie 21, Helsinki
+    123 Venäläinen koulu, Helsinki
+    124 Alakaupunki, Espoo
+    124 Fleminginkatu 23, Helsinki
+    124 Fleminginkatu 25, Helsinki
+    124 Haapaniemenrinne 1, Espoo
+    124 Kala-matti 1, Espoo
+    124 Kirkkokatu 6, Helsinki
+    124 Kirstintie 30, Espoo
+    124 Kivelän sairaala, Helsinki
+    124 Kylänvanhimmantie 29, Helsinki
+    124 Köydenpunojankatu 8, Helsinki
+    124 Mannerheimintie 14, Helsinki
+    124 Mannerheimintie 3, Helsinki
+    124 Porintie 1, Helsinki
+    124 Rinnekoti, Espoo
+    124 Rörstrandinkatu 1, Helsinki
+    124 Takojankuja 1, Kerava
+    125 Kangasalantie 13, Helsinki
+    125 Katajaharju, Helsinki
+    125 Kauppamiehentie 1, Espoo
+    125 Kämnerintie 4, Helsinki
+    125 Lautatarhankatu 6, Helsinki
+    125 Portti 1, Espoo
+    125 Purotie 8, Helsinki
+    125 Pursimiehenkatu 26, Helsinki
+    125 Suezinkatu 3, Helsinki
+    125 Takomotie 23, Helsinki
+    125 Trillakatu 1, Espoo
+    125 Vilhonvuorenkatu 1, Helsinki
+    125 Väinölänkatu 2, Helsinki
+    126 Dagmarinkatu 3, Helsinki
+    126 Helsinginkatu 15, Helsinki
+    126 HKI, Helsinki
+    126 Isonniitynkatu 3, Helsinki
+    126 Kaitaan koulu, Espoo
+    126 Kanavaranta 7, Helsinki
+    126 Kiillekuja 3, Helsinki
+    126 Koivumäentie 16, Vantaa
+    126 Kontukuja 5, Helsinki
+    126 Lapinlahdenkatu 1, Helsinki
+    126 Liusketie 3, Helsinki
+    126 Pohjoinen Hesperiankatu 1, Helsinki
+    126 Pyhtäänkorvenkuja 6, Vantaa
+    126 Ryytimaa 1, Espoo
+    126 Siltakuja 1, Espoo
+    126 Sörnäisten Rantatie 6, Helsinki
+    126 Tuusulantaival 42, Kerava
+    126 Töölöntullinkatu 1, Helsinki
+    126 Viikintie 1, Helsinki
+    127 Albertinkatu 1, Helsinki
+    127 Aleksis Kiven katu 3, Helsinki
+    127 Castreninkatu 18, Helsinki
+    127 Dagmarinkatu 5, Helsinki
+    127 Helsingintie 10, Kauniainen
+    127 Hiomotie 42, Helsinki
+    127 Itämerenkatu 3, Helsinki
+    127 Itäportti 1, Espoo
+    127 Kaarlenkatu 1, Helsinki
+    127 Kaupintie 14, Helsinki
+    127 Koisotie 4, Vantaa
+    127 Maapadontie 1, Helsinki
+    127 Maininkitie 9, Espoo
+    127 Perkkaantie 3, Espoo
+    127 Poutamäentie 13, Helsinki
+    127 Savelantie 3, Helsinki
+    127 Siilitie 7, Helsinki
+    127 Sturenkatu 25, Helsinki
+    127 Tyynenmerenkatu 3, Helsinki
+    127 Vanha Turuntie 14, Kauniainen
+    128 Aleksanterinkatu 9, Helsinki
+    128 Brahenkatu, Helsinki
+    128 Erkki Melartinin tie 1, Helsinki
+    128 Eteläranta 1, Helsinki
+    128 Hämeenlinnanväylä, Helsinki
+    128 Keilalahdentie 4, Espoo
+    128 Maistraatinkatu 1, Helsinki
+    128 Matinkatu 22, Espoo
+    128 Minnesstensstigen 1, Helsinki
+    128 Mätästie 1, Helsinki
+    128 Porthaninkatu 15, Helsinki
+    128 Ratamestarinkatu 11, Helsinki
+    128 Simonkatu 9, Helsinki
+    128 Unioninkatu 37, Helsinki
+    128 Varikkotie 2, Helsinki
+    128 Viljo Sohkasen katu 3, Vantaa
+    129 Hankasuontie 11, Helsinki
+    129 Kaadekuja 1, Helsinki
+    129 Kaasutehtaankatu 1, Helsinki
+    129 Katajalaakso 1, Espoo
+    129 Kivihaantie 1, Helsinki
+    129 Kivikonkaari 14, Helsinki
+    129 Laajalahdentie 23, Helsinki
+    129 Laurea Leppävaara, Espoo
+    129 Liisankatu 16, Helsinki
+    129 Mannerheimintie 91, Helsinki
+    129 Melkonkatu 1, Helsinki
+    129 Myllypurontie 1, Helsinki
+    129 Myllypurontie 22, Helsinki
+    129 Olympiaranta 1, Helsinki
+    129 Otaniementie 9, Espoo
+    129 Piilipuuntie 31, Espoo
+    129 Rajamänty, Espoo
+    129 Runeberginkatu 43, Helsinki
+    129 Tammasaarenkatu 1, Helsinki
+    129 Unikkotie 5, Vantaa
+    129 Viherkalliontie 7, Espoo
+    130 Anjankuja 3, Espoo
+    130 Haaga, Helsinki
+    130 Hakaniemenranta 6, Helsinki
+    130 Hansatie 4, Espoo
+    130 Hämeentie 85, Helsinki
+    130 Karhunkierros 4, Vantaa
+    130 Kauniala, Kauniainen
+    130 Kivalterintie 20, Helsinki
+    130 Leppälinnunrinne 6, Espoo
+    130 Maasälväntie 5, Helsinki
+    130 Mannerheimintie 40, Helsinki
+    130 Mikonkatu 8, Helsinki
+    130 Otaniementie 1, Espoo
+    130 Vaakatie 6, Helsinki
+    131 Antti Korpin tie 1, Helsinki
+    131 Friisilä, Espoo
+    131 Lintulahdenkuja 4, Helsinki
+    131 Mechelininkatu 3, Helsinki
+    131 Museokatu 1, Helsinki
+    131 Nauvontie 18, Helsinki
+    131 Pasilanraitio 10, Helsinki
+    131 Pyyntitie 1, Espoo
+    131 Ratakatu 1, Helsinki
+    131 Tunnelitie 1, Kauniainen
+    131 Tuulikuja 2, Espoo
+    131 Työpajankatu 13, Helsinki
+    132 Docksgatan, Helsinki
+    132 Energiakuja 3, Helsinki
+    132 Helsinginkatu 13, Helsinki
+    132 Hämeentie 32, Helsinki
+    132 Joupinpuisto 1, Espoo
+    132 Katajanokka Terminal, Helsinki
+    132 Kuuluttajankatu 2, Helsinki
+    132 Lumikintie 3, Helsinki
+    132 Malminkatu 3, Helsinki
+    132 Miestentie 1, Espoo
+    132 Niittyportti 4, Espoo
+    132 Pasilan asema, Helsingfors
+    132 Pohjoinen Hesperiankatu 15, Helsinki
+    132 Seltterikuja 4, Helsinki
+    132 Talin keilahalli, Helsinki
+    132 Televisiokatu 4, Helsinki
+    132 Ukonvaaja 1, Espoo
+    132 Vellamonkatu 1, Helsinki
+    133 Elimäenkatu 1, Helsinki
+    133 Haukilahdensolmu, Espoo
+    133 Kokkokalliontie 3, Helsinki
+    133 Laajasuontie 31, Helsinki
+    133 Mannerheimintie 43, Helsinki
+    133 Otto Brandtin tie 16, Helsinki
+    133 Puistomäki 1, Espoo
+    133 Pääskylänrinne 3, Helsinki
+    133 Radiokatu 11, Helsinki
+    133 Ruoholahdenkatu 21, Helsinki
+    133 Sähkötie 5, Vantaa
+    133 Untamontie 1, Helsinki
+    133 Untamontie 9, Helsinki
+    134 Adolf Lindforsin tie, Helsinki
+    134 Atomitie 5, Helsinki
+    134 Fredrikinkatu 12, Helsinki
+    134 Harustie 7, Helsinki
+    134 Hiekkaharjun asema, Vantaa
+    134 Kielotie 13, Vantaa
+    134 Kipparlahden Silmukka 1, Helsinki
+    134 Koskelantie 5, Helsinki
+    134 Kuunkatu 1, Espoo
+    134 Käpyläntie 2, Helsinki
+    134 Neljäs Linja 2, Helsinki
+    134 Otakallio 1, Espoo
+    134 Sulkapolku 6, Helsinki
+    134 Sumatrantie 1, Helsinki
+    134 Svanströminkuja 1, Helsinki
+    134 Teollisuuskatu 18, Helsinki
+    135 Antaksentie 4, Vantaa
+    135 Arkadiankatu 28, Helsinki
+    135 Eiran aikuislukio, Helsinki
+    135 Emännänkuja 1, Vantaa
+    135 Kampin terminaali, Helsinki
+    135 Kanneltie 2, Helsinki
+    135 Karpalokuja 7, Helsinki
+    135 Katajanokanlaituri 8, Helsinki
+    135 Keilasatama 5, Espoo
+    135 Kyllikinportti 2, Helsinki
+    135 Kylmäojantie 1, Vantaa
+    135 Laajasuontie 35, Helsinki
+    135 Laaksotie 20, Vantaa
+    135 Lapinlahdenkatu 16, Helsinki
+    135 Lönnrotinkatu 1, Helsinki
+    135 Porslahdentie 24, Helsinki
+    135 Snellmaninkatu, Helsinki
+    135 Turunlinnantie 1, Helsinki
+    135 Unioninkatu 45, Helsinki
+    135 Vanha Talvitie 19, Helsinki
+    135 Viikin biokeskus, Helsinki
+    135 Vilppulantie 26, Helsinki
+    136 Eliel Saarisen tie 15, Helsinki
+    136 Heiniitty 5, Espoo
+    136 Herttoniemen sairaala, Helsinki
+    136 Hietapellontie 11, Helsinki
+    136 Kasarminkatu ks. Kasarmikatu, Helsinki
+    136 Klariksentie 1, Espoo
+    136 Kyllikinportti 1, Helsinki
+    136 Käskynhaltijantie 5, Helsinki
+    136 Lehtikallio 4, Vantaa
+    136 Leppälinnunrinne 1, Espoo
+    136 Maistraatinportti 2, Helsinki
+    136 Mannerheimintie 6, Helsinki
+    136 Metsäläntie 2, Helsinki
+    136 Nuijamiestentie 7, Helsinki
+    136 Opastinsilta 9, Helsinki
+    136 Pakkala, Vantaa
+    136 Riistavuorenkuja 4, Helsinki
+    136 Sturenkatu 22, Helsinki
+    136 Talvelantie 6, Helsinki
+    136 Tynnyrintekijänkatu 1, Helsinki
+    137 Etelä-Tapiolan lukio, Espoo
+    137 Fleminginkatu 13, Helsinki
+    137 Henrikintie 5, Helsinki
+    137 Hirsipadontie 7, Helsinki
+    137 Kaisaniemi Park, Helsinki
+    137 Lahtisvägen 759, Sipoo
+    137 Myllynkivenkuja 6, Vantaa
+    137 Neilikkatie 17, Vantaa
+    137 Porkkalankatu 24, Helsinki
+    137 Pyynikintie 1, Helsinki
+    137 Sturenkatu 7, Helsinki
+    137 Suvilahdenkatu 9, Helsinki
+    138 Annankatu 29, Helsinki
+    138 Bulevardi 32, Helsinki
+    138 Eduskuntatalo, Helsinki
+    138 Hyrylä, -
+    138 Hämeentie 17, Helsinki
+    138 Keinulaudantie 7, Helsinki
+    138 Kätilöopisto, Laituri 2, Helsinki
+    138 Maistraatinkatu 7, Helsinki
+    138 Mannerheimintie 20, Helsinki
+    138 Mustialankatu 3, Helsinki
+    138 Pohjolankatu 2, Helsinki
+    138 SMT, Espoo
+    138 Terhotie 1, Vantaa
+    138 Turkismiehentie 8, Helsinki
+    138 Unioninkatu 1, Helsinki
+    138 Valimotie 13, Helsinki
+    138 Vuorenpeikontie 1, Helsinki
+    139 Hämeentie 155, Helsinki
+    139 Kaunispääntie 1, Helsinki
+    139 Matinkylän jäähalli, Espoo
+    139 Pohjolankatu 1, Helsinki
+    139 Tehtaankatu 34, Helsinki
+    139 Tilkuntie 5, Vantaa
+    140 Alppikatu 3, Helsinki
+    140 Eteläesplanadi 1, Helsinki
+    140 Fazerila, Vantaa
+    140 Hagelstamintie 32, Vantaa
+    140 Laajalahdentie 30, Helsinki
+    140 Leppäsuonkatu 7, Helsinki
+    140 Paraistentie 17, Helsinki
+    140 Sanomala, Vantaa
+    140 Sepetlahdentie 1, Espoo
+    140 Servin Maijan tie 6, Espoo
+    140 Sähkötie 3, Vantaa
+    140 Takaniityntie 5, Helsinki
+    140 Upseerinkatu 1, Espoo
+    141 Antaksentie 1, Vantaa
+    141 Atomitie 2, Helsinki
+    141 Eerikinkatu 11, Helsinki
+    141 Kuitinmäki, Espoo
+    141 Ristipellontie 1, Helsinki
+    141 Tietotie 3, Espoo
+    142 Itämerenkatu 5, Helsinki
+    142 Jännetie 1, Helsinki
+    142 Katajanokanranta 21, Helsinki
+    142 Kylänvanhimmantie 25, Helsinki
+    142 Lääkärinkatu 2, Helsinki
+    142 Mannerheimintie 41, Helsinki
+    142 Näyttelijäntie 1, Helsinki
+    142 Radiokatu 22, Helsinki
+    142 Runeberginkatu 22, Helsinki
+    142 Sisarustentie 2, Helsinki
+    142 Sturenkatu 5, Helsinki
+    142 Vähäntuvantie 1, Helsinki
+    142 Välskärinkatu 12, Helsinki
+    143 Juvanmalmi, Espoo
+    143 Kalteentie 1, Helsinki
+    143 Kääpiöidenpolku 4, Helsinki
+    143 Narinkka 1, Helsinki
+    143 Otakaari 3, Espoo
+    143 Pieni Roobertinkatu 1, Helsinki
+    143 Seurasaari, Helsinki
+    143 Siltamäen ostosk., Helsinki
+    143 Vattuniemenkatu 18, Helsinki
+    144 Auroranmäki 1, Espoo
+    144 Haahkatie 15, Helsinki
+    144 Kivalterintie 21, Helsinki
+    144 Käenkuja 8, Helsinki
+    144 Runeberginkatu 40, Helsinki
+    144 Sähkötie 1, Vantaa
+    144 Taivalmäki 1, Espoo
+    144 Tilanhoitajankaari 1, Helsinki
+    144 Ulvilantie 23, Helsinki
+    145 Ajomiehentie 1, Helsinki
+    145 Elimäenkatu 2, Helsinki
+    145 Hämeentie 38, Helsinki
+    145 Jämsänkatu 2, Helsinki
+    145 Kalkkipellontie 4, Espoo
+    145 Kielotie 1, Vantaa
+    145 Mikonkatu 7, Helsinki
+    145 Mätästie 5, Helsinki
+    146 Haahkakuja 5, Helsinki
+    146 Hevosmiehenkatu 13, Helsinki
+    146 Kirkonkyläntie 23, Helsinki
+    146 Kirstinkatu 15, Helsinki
+    146 Lentoasema T1, Vantaa
+    146 Mantelikuja 1, Vantaa
+    146 Sopulirinne 2, Helsinki
+    147 Antaksentie 21, Vantaa
+    147 Asemamiehenkatu 4, Helsinki
+    147 Kirjanpitäjänkuja 4, Espoo
+    147 Kirstinmäki 1, Espoo
+    147 Moisiontie 1, Helsinki
+    147 Robert Huberin tie 4, Vantaa
+    147 Salpausseläntie 13, Helsinki
+    147 Santakatu 2, Helsinki
+    147 Strömbergintie 8, Helsinki
+    147 Valimotie 11, Vantaa
+    148 Aleksis Kiven katu 56, Helsinki
+    148 Kaupintie 1, Helsinki
+    148 Kaupintie 4, Helsinki
+    148 Kutomotie 2, Helsinki
+    148 Latokartanonkaari 9, Helsinki
+    148 Otsolahdentie 5, Espoo
+    148 Petas, Espoo
+    148 Rekolan asema, Vantaa
+    148 Tarhurintie 2, Vantaa
+    148 Valimotie 7, Vantaa
+    148 Vallinoja, Vantaa
+    149 Elimäenkatu 17, Helsinki
+    149 Heikinlaakso, Helsinki
+    149 Hirsipadontie 1, Helsinki
+    149 Jönsaksentie 4, Vantaa
+    149 Kaarelantie 86, Helsinki
+    149 Kampinkuja 2, Helsinki
+    149 Keikarinkuja 1, Vantaa
+    149 Keskuskatu 1, Helsinki
+    149 Käräjäkuja 1, Vantaa
+    149 Nihtitorpankuja 3, Espoo
+    149 Nordenskiöldinkatu 12, Helsinki
+    149 Nöykkiön koulu, Espoo
+    149 Porkkalankatu 5, Helsinki
+    149 Porthaninkatu 1, Helsinki
+    149 Päärautatieasema, Helsinki
+    149 Siltavoudintie 14, Helsinki
+    149 Suvilahdenkatu 1, Helsinki
+    149 Visamäki, Espoo
+    150 Annankatu 1, Helsinki
+    150 Itäinen puistotie 14, Helsinki
+    150 Kalevankatu 3, Helsinki
+    150 Näyttelijäntie 18, Helsinki
+    150 Paciuksenkatu 27, Helsinki
+    150 Siltasaarenkatu 18, Helsinki
+    150 Tuulimyllyntie 1, Helsinki
+    150 Uudenmaankatu 1, Helsinki
+    151 Karakallion koulu, Espoo
+    151 Samaria, Espoo
+    151 Siltavuorenpenger 3, Helsinki
+    151 Tilanhoitajankaari 12, Helsinki
+    152 Aleksanterinkatu 52, Helsinki
+    152 Arabiankatu 1, Helsinki
+    152 Iso Roobertinkatu 1, Helsinki
+    152 Kamreerintie 3, Espoo
+    152 Lehtikuusentie 4, Helsinki
+    152 Puotila metroasema, Helsinki
+    152 Rekipellontie 15, Helsinki
+    152 Valimotie 19, Vantaa
+    152 Vilhonvuorenkatu 11, Helsinki
+    153 Eerikinkatu 1, Helsinki
+    153 Hämeentie 13, Helsinki
+    153 Kaitaa, Espoo
+    153 Kipparinkuja 1, Espoo
+    153 Kivistö, Vantaa
+    153 Koivukyläntie 47, Vantaa
+    153 Kylävainionkuja 6, Espoo
+    153 Louhelan asema, Vantaa
+    153 Paloheinä, Helsinki
+    153 Porvoonkatu 27, Helsinki
+    153 Ruoholahdenkatu 23, Helsinki
+    153 Saanatunturintie 1, Helsinki
+    153 Teknobulevardi 3, Vantaa
+    153 Venevalkamantie 9, Kauniainen
+    153 Viikinranta, Helsinki
+    154 Elimäenkatu 25, Helsinki
+    154 Hämeentie 111, Helsinki
+    154 Kilonkartanontie 1, Espoo
+    154 Kuusikkotie 3, Helsinki
+    154 Lokkalantie 1, Helsinki
+    154 Mannerheimintie 30, Helsinki
+    154 Martinkyläntie 39, Vantaa
+    154 Riihenkulma 1, Helsinki
+    154 Viherlaaksonranta 10, Espoo
+    155 Hakaniemi, Helsinki
+    155 Itätuulenkuja 8, Espoo
+    155 Kaupintie 16, Helsinki
+    155 Leppävaaran lukio, Espoo
+    155 Luoma, Kirkkonummi
+    155 Mannerheimintie 107, Helsinki
+    155 Roomankatu 5, Helsinki
+    155 Soukanaukio, Espoo
+    155 Stenbäckinkatu 1, Helsinki
+    155 Tekniikantie 4, Espoo
+    155 Viittakorpi 1, Espoo
+    155 Yliopistonkatu 1, Helsinki
+    156 Ajomiehentie 14, Helsinki
+    156 Aku Korhosen tie 2, Helsinki
+    156 Hitsaajankatu 1, Helsinki
+    156 Kannelmäki railway station, Helsinki
+    156 Kielotie 11, Vantaa
+    156 Krogiuksentie 17, Helsinki
+    156 Käpyläntie 12, Helsinki
+    156 Lauttasaaren yhteiskoulu, Helsinki
+    156 Malmin lentoasema, Helsinki
+    156 Neitsytpolku 1, Helsinki
+    156 Niittymaanaukea 2, Espoo
+    156 Pengerkatu 1, Helsinki
+    156 Rälssitie 13, Vantaa
+    156 Siilitie 9, Helsinki
+    157 Hakarinne 2, Espoo
+    157 Illenpiha 4, Vantaa
+    157 Jakomäen ostosk., Helsinki
+    157 Marsinkuja 1, Vantaa
+    157 Oltermannintie 32, Helsinki
+    157 Porvoonkatu 15, Helsinki
+    157 Suursuonlaita 1, Helsinki
+    158 Helsinki City, Helsinki
+    158 Hietalahdentori, Helsinki
+    158 Kaarelankuja 2, Helsinki
+    158 Kilpolantie 16, Helsinki
+    158 Otaranta 8, Espoo
+    158 Rapakivenkuja 1, Helsinki
+    158 Sturenkatu 16, Helsinki
+    158 Tilanhoitajankaari 3, Helsinki
+    158 Tilkankatu 2, Helsinki
+    158 Topeliuksenkatu 1, Helsinki
+    158 Trillakatu 5, Espoo
+    159 Lehtikuusentie 1, Helsinki
+    159 Lippajärvi, Espoo
+    159 Mäkitorpantie 3, Helsinki
+    159 Piispanpiha 4, Espoo
+    159 Radiokatu 1, Helsinki
+    159 Ratavartijankatu 5, Helsinki
+    159 Salomonkatu 17, Helsinki
+    159 Suokki, Helsinki
+    160 Kallion kirkko, Helsinki
+    160 Kerttulinkuja 1, Helsinki
+    160 Kulovalkeantie 21, Espoo
+    160 Kyläsaarenkatu 8, Helsinki
+    160 Meritullinkatu 1, Helsinki
+    160 Mäkelänkatu 4, Helsinki
+    160 Näyttelijäntie 15, Helsinki
+    160 Palkkatilanportti 1, Helsinki
+    160 Pyöräilystadion, Helsinki
+    160 Suvilahti, Helsinki
+    160 Töölöntulli 2, Helsinki
+    160 Upseerinkatu 11, Espoo
+    160 Vihdintie 1, Helsinki
+    161 Hämeentie 156, Helsinki
+    161 Hämeentie 9, Helsinki
+    161 Kaisaniemi, Helsinki
+    161 Kipparinkatu 2, Espoo
+    161 Kivalterintie 17, Helsinki
+    161 Kotkatie 6, Espoo
+    161 Kumpulantie 9, Helsinki
+    161 Lipparinne 1, Espoo
+    161 Mechelininkatu 12, Helsinki
+    161 Messeniuksenkatu 1, Helsinki
+    161 Neljäs Linja 1, Helsinki
+    161 Ruotsinpiha 1, Vantaa
+    161 Tilkankatu 39, Helsinki
+    162 Hämeentie 15, Helsinki
+    162 Kasavuorentie 1, Kauniainen
+    162 Mannerheiminaukio 1, Helsinki
+    162 Olarin koulu, Espoo
+    162 Pasilan puistotie 6, Helsinki
+    162 Raumantie 4, Helsinki
+    162 Tammistonkatu 23, Vantaa
+    163 Arkadiankatu 22, Helsinki
+    163 Aurorakoti, Espoo
+    163 Eläintarhantie 5, Helsinki
+    163 Kuunkehrä 2, Espoo
+    163 Lotankatu 1, Espoo
+    163 Martinkyläntie 48, Vantaa
+    163 Merikasarminkatu 1, Helsinki
+    163 Myrttitie 2, Helsinki
+    163 Sörnäisten Rantatie 27, Helsinki
+    164 Hämeentie 11, Helsinki
+    164 Kilonpuiston koulu, Espoo
+    164 Kulorastaantie 3, Vantaa
+    164 Leppäkorpi, Vantaa
+    164 Merimiehenkatu 36, Helsinki
+    164 Siilitie 1, Helsinki
+    164 Ukkostie 1, Helsinki
+    164 Yrjönkatu 24, Helsinki
+    165 Ilmarinkatu 1, Helsinki
+    165 Itätuulenkuja 1, Espoo
+    165 Kirkkonummi railway station, Kirkkonummi
+    165 Louhikkotie 20, Helsinki
+    165 Mannerheimintie 100, Helsinki
+    165 Rasinkatu 10, Vantaa
+    165 Soittajantie 3, Helsinki
+    165 Säterinkatu 6, Espoo
+    165 Tarhurintie 1, Vantaa
+    165 Turuntie 42, Espoo
+    165 Vuorikatu 19, Helsinki
+    166 Annankatu 32, Helsinki
+    166 Jousenkaari 5, Espoo
+    166 Lauttasaarentie 1, Helsinki
+    166 Otaniementie 19, Espoo
+    166 Pirjontie 1, Helsinki
+    167 Gyldenintie 1, Helsinki
+    167 Haapaniemenkatu 14, Helsinki
+    167 Haapaniemenkatu 1, Helsinki
+    167 Ilkantie 3, Helsinki
+    167 Isokaari 1, Helsinki
+    167 Kauniaisten lukio, Kauniainen
+    167 Louhikkotie 1, Helsinki
+    167 Puunhaltijankuja 2, Vantaa
+    168 Haaga-Helia, Helsinki
+    168 Iso puistotie 1, Helsinki
+    168 Kielotie 5, Vantaa
+    168 Mannerheimintie 12, Helsinki
+    168 Vanha Viertotie 9, Helsinki
+    169 Airport T2, Vantaa
+    169 Aleksanterinkatu 15, Helsinki
+    169 Hilapellontie 4, Helsinki
+    169 Jaakonkatu 3, Vantaa
+    169 Lentoasema, terminaali 2, Vantaa
+    169 Nordenskiöldinkatu 20, Helsinki
+    169 Pursimiehenkatu 1, Helsinki
+    170 Kampintori, Helsinki
+    170 Keskuskatu 7, Helsinki
+    170 Kämnerintie 7, Helsinki
+    170 Mannerheimintie 160, Helsinki
+    170 Pursimiehenkatu 29, Helsinki
+    170 Päiväkumpu, Vantaa
+    170 Sörnäisten Rantatie 31, Helsinki
+    171 Huopalahdentie 28, Helsinki
+    171 Iso Paja, Helsinki
+    171 Mannerheimintie 10, Helsinki
+    171 Rajatie 7, Helsinki
+    171 Rastasniityntie 1, Espoo
+    171 Tornihaukantie 6, Espoo
+    171 Välimerenkatu 9, Helsinki
+    172 Alakiventie 2, Helsinki
+    172 Kaivopiha, Helsinki
+    172 Koskelantie 72, Helsinki
+    172 Laajasalo, Helsinki
+    172 Muurala, Espoo
+    172 Panuntie 11, Helsinki
+    172 Rautkalliontie 1, Vantaa
+    172 Ristipellontie 6, Helsinki
+    172 Suvilahdenkatu 10, Helsinki
+    172 Sörnäinen(M), Helsinki
+    172 Töölönkatu 1, Helsinki
+    173 Järvenperän koulu, Espoo
+    173 Kokkokalliontie 9, Helsinki
+    173 Meri-rastilan tie 1, Helsinki
+    173 Pasilanraitio 13, Helsinki
+    173 Unioninkatu 38, Helsinki
+    174 Hämeentie 105, Helsinki
+    174 Junailijankuja 1, Helsinki
+    174 Kolkekannaksentie 1, Espoo
+    174 Laajalahdentie 21, Helsinki
+    174 Lentoasema, terminaali 1, Vantaa
+    174 Niipperi, Espoo
+    174 Tikkurilantie 140, Vantaa
+    174 Vanha Porvoontie 229, Vantaa
+    175 A.i. Virtasen aukio 1, Helsinki
+    175 Heinjoenpolku 1, Espoo
+    175 Juhana Herttuan tie, Helsinki
+    175 Maamiehentie 2, Helsinki
+    175 Mannerheimintie 13, Helsinki
+    175 Museokatu 44, Helsinki
+    175 Myllypuro metroasema, Helsinki
+    175 Niemenmäki, Helsinki
+    175 Soukanniementie 1, Espoo
+    175 Sturenkatu 21, Helsinki
+    175 Tolsa, Kirkkonummi
+    176 Itämerentori 2, Helsinki
+    176 Jakomäentie 10, Helsinki
+    176 Kaivosrinteentie 1, Vantaa
+    176 Karantie 2, Espoo
+    176 Mannerheimintie 170, Helsinki
+    176 Paraistentie 19, Helsinki
+    176 Piilipuuntie 1, Espoo
+    176 Puosunrinne 1, Espoo
+    177 Jarrumiehenkatu 2, Helsinki
+    177 Kyyhkysmäki 2, Espoo
+    177 Mannerheimintie 15, Helsinki
+    177 Mannerheimintie 55, Helsinki
+    177 Palkkatilankatu 9, Helsinki
+    177 Ratsastie 10, Helsinki
+    177 Rautalammintie 2, Helsinki
+    177 Roihuvuorentie 20, Helsinki
+    177 Rummunlyöjänkatu 3, Espoo
+    177 Taimistontie 4, Helsinki
+    177 Venuksentie 6, Vantaa
+    178 Kapteeninkatu 1, Helsinki
+    178 Leppäsuonkatu 11, Helsinki
+    178 Rautatientori, Helsingfors
+    178 Suovakuja 1, Helsinki
+    178 Viikinkaari 2, Helsinki
+    179 Kaisaniemenkatu 1, Helsinki
+    179 Kaivomestarinkatu 1, Espoo
+    179 Keilaranta 21, Espoo
+    179 Kivenlahdenkatu 1, Espoo
+    179 Käpylänkuja 1, Helsinki
+    179 Lehtisaarentie 1, Helsinki
+    179 Ulappakatu 1, Espoo
+    179 Vanha Viertotie 1, Helsinki
+    180 Alppikatu 15, Helsinki
+    180 Länsimäki, Vantaa
+    180 Mannerheimintie 166, Helsinki
+    180 Timpurinkuja 1, Espoo
+    180 Töölönlahdenkatu 3, Helsinki
+    180 Vanhanlinnantie 1, Helsinki
+    180 Vaskihuhdantie 1, Helsinki
+    181 Haapaniemenkatu 6, Helsinki
+    181 Huovitie 5, Helsinki
+    181 Itämerenkatu 11, Helsinki
+    181 Laajalahti, Espoo
+    181 Landbo, Helsinki
+    181 Ruoholahdenkatu 14, Helsinki
+    182 Koivukyläntie 51, Vantaa
+    182 Ojahaantie 5, Vantaa
+    182 Piilipuuntie 21, Espoo
+    182 Ratamestarinkatu 7, Helsinki
+    183 Adolf Lindforsin tie 1, Helsinki
+    183 Katajanokanlaituri 7, Helsinki
+    183 Liisankatu 13, Helsinki
+    183 Myyrmäki railway station, Vantaa
+    183 Otahalli, Espoo
+    183 Otsonkallio 3, Espoo
+    183 Pietarinkatu 15, Helsinki
+    183 Runeberginkatu 4, Helsinki
+    183 Ruosilantie 2, Helsinki
+    183 Tikkurilantie 148, Vantaa
+    183 Tullinpuomi, Helsinki
+    183 Töölönkatu 28, Helsinki
+    184 Kivihaantie 7, Helsinki
+    184 Klariksentie 2, Espoo
+    184 Kluuvikatu 8, Helsinki
+    184 Pirkkolan urheilupuisto, Helsinki
+    184 Sepontie 2, Espoo
+    184 Sturenkatu 11, Helsinki
+    184 Sörkka, Helsinki
+    184 Tali, Helsinki
+    184 Valimopolku 4, Helsinki
+    185 Espoonlahden lukio, Espoo
+    185 Korjaamo kulttuuritehdas, Helsinki
+    185 Pohjoinen Hesperiankatu 23, Helsinki
+    185 Porvoonkatu 5, Helsinki
+    185 Rautalammintie 5, Helsinki
+    185 Tikkurilan urheilupuisto, Vantaa
+    185 Ulvilantie 21, Helsinki
+    186 Eteläranta 10, Helsinki
+    186 Huovitie 1, Helsinki
+    186 Kala-maija 1, Espoo
+    186 Karhunkierros 2, Vantaa
+    186 Matinkatu 1, Espoo
+    186 Pohjoinen Rautatiekatu 9, Helsinki
+    186 Uudenmaankatu 16, Helsinki
+    187 Iso Roobertinkatu, Helsinki
+    187 Kaikukatu 1, Helsinki
+    187 Koivu-Mankkaan tie, Espoo
+    187 Latokartanonkaari 7, Helsinki
+    187 Maakirjantie 2, Espoo
+    187 Mikonkatu 15, Helsinki
+    187 Mäkelänkatu 86, Helsinki
+    187 Pohjois-Haagan yhteiskoulu, Helsinki
+    188 Hämeenkylä, Vantaa
+    188 Karsikkokuja 15, Vantaa
+    188 Malminiitty, Vantaa
+    188 Nordenskiöldinkatu 11, Helsinki
+    189 Askisto, Vantaa
+    189 Kanneltalo, Helsinki
+    189 Mannerheimintie 9, Helsinki
+    189 Paulankatu 2, Helsinki
+    189 Valimotie 21, Helsinki
+    190 Harustie 8, Helsinki
+    190 Ojahaantie 1, Vantaa
+    190 Osmontie 43, Helsinki
+    190 Paciuksenkaari 1, Helsinki
+    190 Revontulentie 7, Espoo
+    190 Von Daehnin katu, Helsinki
+    191 Kutomotie 8, Helsinki
+    191 Naalitie 21, Vantaa
+    191 Talin puistotie 1, Helsinki
+    191 Vilniementie 1, Espoo
+    192 Havukoski, Vantaa
+    192 Kilonkallio 10, Espoo
+    192 Kilonportti 1, Espoo
+    192 Länsituulentie 1, Espoo
+    192 Nordenskiöldinkatu 18, Helsinki
+    192 Radiokatu 20, Helsinki
+    192 Sentnerikuja 1, Helsinki
+    192 Sturenkatu 40, Helsinki
+    192 Tiimalasintie 1, Espoo
+    193 Dynamicum Kumpula, Helsinki
+    193 Kaj Franckin katu 1, Helsinki
+    193 Kamppi, Helsingfors
+    193 Karakalliontie 1, Espoo
+    193 Strömberginkuja 3, Helsinki
+    194 Harjannetie 44, Helsinki
+    194 Hämeentie 19, Helsinki
+    194 Kampen, Helsingfors
+    194 Lämmittäjänkatu 2, Helsinki
+    194 Myyrmäentie 4, Vantaa
+    194 Porttipuistontie 1, Vantaa
+    194 Teollisuuskatu 15, Helsinki
+    195 Alppikatu 5, Helsinki
+    195 Heikkiläntie 7, Helsinki
+    195 Kalastajanmäki 1, Espoo
+    196 Alaportti 1, Espoo
+    196 Kontulankaari 11, Helsinki
+    196 Latokartano, Helsinki
+    196 Maakaari 1, Helsinki
+    197 Arkadiankatu 26, Helsinki
+    197 Eira, Helsinki
+    197 Lintuvaara, Espoo
+    197 Näyttelijäntie 14, Helsinki
+    197 Sturenkatu 13, Helsinki
+    197 Tunturikatu 16, Helsinki
+    197 Tyynenmerenkatu 1, Helsinki
+    197 Vitikka 1, Espoo
+    198 Lehtikuusentie 6, Helsinki
+    198 Perhonkatu 11, Helsinki
+    198 Servin Maijan tie 12, Espoo
+    198 Urho Kekkosen katu 1, Helsinki
+    198 Viikintori 3, Helsinki
+    198 Väinö Tannerin tie 1, Vantaa
+    199 Kylävainiontie 20, Espoo
+    199 Tapionaukio 1, Espoo
+    199 Tilkankatu 1, Helsinki
+    200 Aleksis Kiven katu 9, Helsinki
+    200 Karvaamokuja 2, Helsinki
+    200 Sotungin koulu, Vantaa
+    200 Varisto, Vantaa
+    201 JMT, Espoo
+    201 Kirstintie 1, Espoo
+    201 Laaksolahti, Espoo
+    201 Mannerheimintie 103, Helsinki
+    201 Palkkatilankatu 1, Helsinki
+    201 Ruorimiehenkatu 1, Espoo
+    201 Serkustentie 1, Helsinki
+    202 Elimäenkatu 15, Helsinki
+    202 Latokartanontie 16, Helsinki
+    202 Sturenkatu 18, Helsinki
+    202 Tapiolan urheilupuisto, Espoo
+    203 Haapaniemenkatu 4, Helsinki
+    203 Ida Aalbergin tie 3, Helsinki
+    203 Kaj Franckin katu 4, Helsinki
+    203 Kalastajankuja 1, Espoo
+    203 Lummetie 2, Vantaa
+    203 Näkinkuja 3, Helsinki
+    203 Pajuniityntie 10, Helsinki
+    203 Sauvatie 1, Vantaa
+    203 Vaarala, Vantaa
+    203 Vesirattaanmäki 1, Espoo
+    204 Helsingin luonnontiedelukio, Helsinki
+    204 Mäkelänkatu 47, Helsinki
+    204 Siilitie metroasema, Helsinki
+    205 Paraistentie 18, Helsinki
+    205 Sanomatalo, Helsinki
+    205 Urheilukatu 10, Helsinki
+    206 Mechelininkatu 1 a, Helsinki
+    206 Pihlajisto, Helsinki
+    206 Sörnäisten Rantatie 1, Helsinki
+    206 Tapiola Shopping Centre, Espoo
+    206 Viikin kirjasto, Helsinki
+    207 Brysselinkatu 3, Helsinki
+    207 Haapaniemi, Helsinki
+    207 Hämeentie 152, Helsinki
+    207 Kivihaka, Helsinki
+    207 Maakaari 6, Helsinki
+    207 Mäkelänrinne 5, Helsinki
+    207 Nauvontie 3, Helsinki
+    207 Pasilanraitio 5, Helsinki
+    208 Maauunintie 19, Vantaa
+    208 Pasilankatu 2, Helsinki
+    208 Pohjoinen Rautatiekatu 29, Helsinki
+    208 Tukkitie 18, Helsinki
+    209 Betonimiehenkuja 5, Espoo
+    209 Matinniitty 1, Espoo
+    209 Työpajankatu 2, Helsinki
+    209 Ulvilantie 27, Helsinki
+    210 Killinmäki, Kirkkonummi
+    210 Paavo Nurmen kuja 1, Helsinki
+    210 Puumiehenkuja 2, Espoo
+    210 Puutarhurinkuja 2, Helsinki
+    210 Rastila metroasema, Helsinki
+    210 Servinkuja 1, Espoo
+    210 Suursuon sairaala, Helsinki
+    210 Vantaankosken koulu, Vantaa
+    211 Majurinkatu 12, Espoo
+    211 Sturenkatu 8, Helsinki
+    211 Viikin normaalikoulu, Helsinki
+    212 Kumpulantie 3, Helsinki
+    212 Tähkäkuja 1, Vantaa
+    212 Viikki Library, Helsinki
+    213 Ahertajantie 1, Espoo
+    213 Liikuntamylly, Helsinki
+    213 Nahkahousuntie 5, Helsinki
+    213 Pajuniityntie 1, Helsinki
+    213 Pietari Hannikaisen tie 1, Helsinki
+    213 Pälkäneentie 13, Helsinki
+    213 Sörnäisten Rantatie 33, Helsinki
+    213 Verkkokauppa.com, Helsinki
+    214 Aleksis Kiven katu 11, Helsinki
+    214 Gustaf Hällströmin katu 1, Helsinki
+    215 Mannerheimintie 96, Helsinki
+    216 Asemakuja 1, Espoo
+    216 Exactum Kumpula, Helsinki
+    216 Kylmäojantie 4, Vantaa
+    216 Pasilan poliisitalo, Helsinki
+    216 Strömbergintie 1, Helsinki
+    216 Vasamatie 1, Espoo
+    217 Alppikatu 1, Helsinki
+    217 Alvar Aallon katu 1, Helsinki
+    217 Jaakonkatu 3, Helsinki
+    217 Kulomäki, Vantaa
+    217 Muotoilijankatu 3, Helsinki
+    217 Pohjois-Haagan asema, Helsinki
+    217 Porkkalankatu 22, Helsinki
+    217 Siilitie 13, Helsinki
+    217 Työväen Akatemia, Kauniainen
+    218 Columbus, Helsinki
+    218 Munkkiniemen yhteiskoulu, Helsinki
+    218 Tekniikantie 14, Espoo
+    219 Liisankuja 2, Espoo
+    219 Ohratie 16, Vantaa
+    219 Pasilanraitio 4, Helsinki
+    220 Itälahdenkatu 22, Helsinki
+    220 Läkkisepäntie 23, Helsinki
+    220 Purotie 1, Helsinki
+    220 Ravals, Kirkkonummi
+    220 Tapionaukio 3, Espoo
+    220 Urheilukatu 1, Helsinki
+    221 Kankaretie 11, Helsinki
+    221 Malmitalo, Helsinki
+    221 Peltokyläntie 1, Helsinki
+    221 Revontulentie 1, Espoo
+    221 Runeberginkatu 55, Helsinki
+    221 Suursuonlaita 3, Helsinki
+    221 Töölöntorinkatu 2, Helsinki
+    221 Viipurinkatu 1, Helsinki
+    222 Aleksis Kiven katu 48, Helsinki
+    222 Ohjaajantie 1, Helsinki
+    222 Otakaari 24, Espoo
+    222 Point, Vantaa
+    223 Ala-malmin Tori 1, Helsinki
+    223 Itätuulentie 1, Espoo
+    223 Kirkkojärven koulu, Espoo
+    223 Martinsillantie 10, Espoo
+    223 Otakaari 18, Espoo
+    223 Pekankatu 5, Helsinki
+    223 Vanha Nurmijärventie 21, Vantaa
+    224 Itäviitta 5, Espoo
+    224 Karaportti 3, Espoo
+    224 Louhelantie 1, Vantaa
+    224 Malminkartanon asema, Helsinki
+    224 Nosturi, Helsinki
+    224 Siltamäki, Helsinki
+    224 Vallilan kirjasto, Helsinki
+    224 Vanha Talvitie 14, Helsinki
+    225 Bunkkeri, Helsinki
+    225 Havukosken koulu, Vantaa
+    225 Lumon lukio, Vantaa
+    225 Muurikuja 1, Helsinki
+    225 Niemitie 1, Helsinki
+    225 Näyttelijäntie 24, Helsinki
+    225 Talvikkitie 119, Vantaa
+    226 Eestinlaakso, Espoo
+    226 Hevosmiehenkatu 1, Helsinki
+    226 Lastenlinnantie 2, Helsinki
+    226 Rajatorpantie 8, Vantaa
+    226 Tyynenmerenkatu 7, Helsinki
+    226 Vanha Turuntie 14, Espoo
+    227 Bulevardi 2, Helsinki
+    227 Kurkisuontie 9, Helsinki
+    227 Mannerheimintie 29, Helsinki
+    227 Tapiolan uimahalli, Espoo
+    228 Hämeentie 2, Helsinki
+    228 Roihuvuori, Helsinki
+    229 Hevosenkenkä 3, Espoo
+    229 Käpyläntie 11, Helsinki
+    229 Läkkisepäntie 21, Helsinki
+    229 Porvoonkatu 3, Helsinki
+    230 Espoon kulttuurikeskus, Espoo
+    230 Liisankatu 1, Helsinki
+    230 Servin Maijan tie 1, Espoo
+    231 Maininkitie 1, Espoo
+    231 TKK, Espoo
+    231 Urheilukatu 5, Helsinki
+    232 Eskolantie 1, Helsinki
+    232 Merivalkama 1, Espoo
+    232 Paasivuorenkatu 5, Helsinki
+    232 Simonkatu 1, Helsinki
+    232 Toinen Linja 14, Helsinki
+    232 Viikinkaari 9, Helsinki
+    233 Eerikinkatu 24, Helsinki
+    233 Malmin Kauppatie 18, Helsinki
+    233 Siltapellonkuja 2, Helsinki
+    233 Viikinportti 2, Helsinki
+    234 Maistraatinportti 3, Helsinki
+    234 Opastinsilta 6, Helsinki
+    234 Siltavoudintie 24, Helsinki
+    234 Viljelijäntie 1, Helsinki
+    234 Väinö Auerin katu 11, Helsinki
+    235 Mannerheimintie 168, Helsinki
+    235 Moisiontie 3, Helsinki
+    235 Sörnäinen Metro Station, Helsinki
+    235 Talonpojantie 5, Helsinki
+    235 Virtatie 4, Vantaa
+    236 Espoontie 21, Espoo
+    236 Kauniaisten asema, Kauniainen
+    236 Martinlaakson lukio, Vantaa
+    236 Pasilanraitio 1, Helsinki
+    236 Televisiokatu 1, Helsinki
+    237 Kirkkokatu 1, Espoo
+    237 Koivukylän koulu, Vantaa
+    237 Kuikkakuja 1, Vantaa
+    237 Pirkkola, Helsinki
+    237 Soukankaari 1, Espoo
+    237 Tilanhoitajankaari 6, Helsinki
+    238 Ahertajantie 2, Espoo
+    238 Arabiankatu 2, Helsinki
+    238 Rautatieläisenkatu 5, Helsinki
+    238 Valimotie 27, Helsinki
+    239 Jorvas, Kirkkonummi
+    239 Kaivokatu 8, Helsinki
+    239 Töölön halli, Helsinki
+    240 Kankaretie 9, Helsinki
+    240 Karaportti 1, Espoo
+    240 Kinopalatsi, Helsinki
+    240 Teollisuuskatu 1, Helsinki
+    240 Tietotie 9, Vantaa
+    240 Turvalaaksontie 1, Vantaa
+    240 Ympyrätalo, Helsinki
+    241 Alempi Talonpojantie 4, Helsinki
+    241 Esport Center, Espoo
+    241 Mechelininkatu 36, Helsinki
+    242 Keilaniemi, Espoo
+    242 Linnankatu 9, Helsingfors
+    242 Pieni Roobertinkatu 12, Helsinki
+    242 Syystie 1, Helsinki
+    243 Itämerenkatu 1, Helsinki
+    243 Lähettilääntie 1, Vantaa
+    243 Ratatie 22, Vantaa
+    244 Kullervonkatu 11, Helsinki
+    244 Kulttuuriaukio 2, Espoo
+    244 Malmin hautausmaa, Helsinki
+    244 Mikonkatu 1, Helsinki
+    245 Arabia kauppakeskus, Helsinki
+    245 Ilkantie 1, Helsinki
+    245 Keilaranta 14, Espoo
+    247 Malmi Park and Ride, Helsinki
+    247 Mäkelänrinteen aikuislukio, Helsinki
+    247 Uutiskatu 5, Helsinki
+    248 Erätie 3, Helsinki
+    248 Mannerheimintie 5, Helsinki
+    248 Miestentie 3, Espoo
+    249 Hämeentie 157, Helsinki
+    249 Munkkivuoren ostosk., Helsinki
+    249 Rautatieasema, Helsingfors
+    250 Fabianinkatu 26, Helsinki
+    250 Linnoituksentie 2, Helsinki
+    250 Opastinsilta 1, Helsinki
+    250 Runeberginkatu 1, Helsinki
+    250 Ruusulankatu 1, Helsinki
+    250 Vaasankatu 2, Helsinki
+    250 Yrjönkatu 30, Helsinki
+    251 Avaruuskatu 4, Espoo
+    251 Mannerheimintie 93, Helsinki
+    252 Kirurginen sairaala, Helsinki
+    252 Savonkatu 4, Helsinki
+    252 Silmupolku 1, Helsinki
+    252 Tikkurilan uimahalli, Vantaa
+    253 Haapaniemenkatu 16, Helsinki
+    253 Jämeräntaival 10, Espoo
+    253 Mäkelänrinteen uintikeskus, Helsinki
+    254 Eiran sairaala, Helsinki
+    254 Iso Omena Shopping Center, Espoo
+    254 Keilaranta 1, Espoo
+    254 Valimotie 9, Vantaa
+    255 Opastinsilta 2, Helsinki
+    255 Salomonkatu 1, Helsinki
+    256 Akanapolku 1, Vantaa
+    256 Helmipöllönkatu 1, Espoo
+    256 Meripihkatie 1, Helsinki
+    256 Varsapuistikko, Helsinki
+    258 Haartmaninkatu 3, Helsinki
+    258 Hietaniemenkatu 14, Helsinki
+    258 Rosendalinkuja 1, Vantaa
+    258 Valimotie 9, Helsinki
+    258 Wanha Satama, Helsinki
+    259 Ratakatu 6, Helsinki
+    259 Tennispuisto, Laituri 31, Espoo
+    260 Kilon asema, Espoo
+    260 Turuntie 150, Espoo
+    261 Kaivokatu 2, Helsinki
+    261 Kyyhkysmäki 1, Espoo
+    261 Matinniitynkuja 1, Espoo
+    261 Sinikalliontie 1, Espoo
+    262 Arielinkatu 2, Helsinki
+    262 Helsinginkatu, Helsinki
+    262 Kauklahden asema, Espoo
+    262 Sturenkatu 27, Helsinki
+    263 Helsinginkatu 58, Helsinki
+    263 Mechelininkatu 34, Helsinki
+    264 Kirstinharju 3, Espoo
+    264 Myrskyläntie 1, Helsinki
+    264 Viides Linja 1, Helsinki
+    265 Berliininkatu 5, Helsinki
+    265 Hämeentie 68, Helsinki
+    266 Fleminginkatu 1, Helsinki
+    266 Intiankatu 21, Helsinki
+    266 Mäkelänkatu 1, Helsinki
+    266 Vanhaistentie 4, Helsinki
+    267 Simonkylän koulu, Vantaa
+    267 Stadi, Helsinki
+    268 Holmankorpi 1, Espoo
+    268 Jupperi, Espoo
+    268 Saunalahden koulu, Espoo
+    268 Toinen Linja 1, Helsinki
+    268 Valtimontie 1, Helsinki
+    269 Koskelantie 3, Helsinki
+    269 Maistraatinportti 1, Helsinki
+    269 Siilitie 11, Helsinki
+    270 Eläintarha, Helsinki
+    270 Väinö Auerin katu 13, Helsinki
+    271 Alppilan lukio, Helsinki
+    271 Lehtisaari, Helsinki
+    271 Mäkipellontie 19, Helsinki
+    272 Hagelstamintie 1, Vantaa
+    272 Vantaankosken asema, Vantaa
+    273 Fazerintie 6, Vantaa
+    273 Kansallismuseo, Helsinki
+    273 Porkkalankatu 13, Helsinki
+    274 Salmisaarenaukio 1, Helsinki
+    275 Terminaali 2, Vantaa
+    275 Vallila, Helsinki
+    276 Hiomotie 13, Helsinki
+    276 Iiluodontie, Helsinki
+    276 Kallion virastotalo, Helsinki
+    277 Haukilahti, Espoo
+    277 Kirstinmäki 7, Espoo
+    277 Mäkelänkatu 56, Helsinki
+    277 Sairaalakatu 1, Vantaa
+    278 Onnentie 18, Helsinki
+    278 Tapiolan keskus, Espoo
+    278 Von Daehnin katu 1, Helsinki
+    278 Ylästö, Vantaa
+    279 Mattlidens gymnasium, Espoo
+    279 Tehtaankatu 1, Helsinki
+    280 Porttisuontie 18, Vantaa
+    280 Upinniemi, Kirkkonummi
+    281 Kitarakuja 3, Helsinki
+    281 Kutojantie 3, Espoo
+    284 Ratapihantie 11, Helsinki
+    285 Rasinkatu 20, Vantaa
+    285 Siltakylänkuja 1, Helsinki
+    286 Kalastajatorpantie 1, Helsinki
+    286 Rosendalinkuja 7, Vantaa
+    286 Vilppulantie 14, Helsinki
+    286 Äyritie 8, Vantaa
+    287 Haartmanin sairaala, Helsinki
+    287 Vanhanlinnantie 3, Helsinki
+    288 Apollonkatu 1, Helsinki
+    288 Kustaankartanon vanhainkoti, Helsinki
+    289 Espoon keskus Park and Ride, Espoo
+    289 Puolarmetsän sairaala, Espoo
+    290 Aalto 1, Espoo
+    290 Sello Library, Espoo
+    290 Ulvilantie 19, Helsinki
+    291 Kirstinkatu 1, Helsinki
+    291 Lastenklinikka, Helsinki
+    291 Von Daehnin katu 14, Helsinki
+    292 Tukholmankatu 8, Helsinki
+    293 Kurkimäentie 19, Helsinki
+    293 Tekniikantie 12, Espoo
+    294 Hietakummuntie 1, Helsinki
+    294 Muusantori 5, Helsinki
+    294 Paciuksenkatu 21, Helsinki
+    295 Agronominkatu 1, Helsinki
+    296 Isokaari 19, Helsinki
+    296 Länsiväylä, Helsinki
+    297 Kolmas Linja 1, Helsinki
+    297 Laajavuorenkuja 1, Vantaa
+    297 Marian sairaala, Helsinki
+    297 Pitäjänmäentie 35, Helsinki
+    297 Ruoholahdenranta 3, Helsinki
+    297 Stenbäckinkatu 11, Helsinki
+    298 Hopeatie 10, Helsinki
+    298 Nihtisillankuja 4, Espoo
+    298 Postintaival 9, Helsinki
+    299 Intiankatu 20, Helsinki
+    300 Laivurinkatu 3, Helsinki
+    301 Oulunkylän yhteiskoulu, Helsinki
+    303 Ahertajantie 5, Espoo
+    304 Ulvilantie 17, Helsinki
+    304 Vieraskuja 5, Espoo
+    305 Bulevardi 1, Helsinki
+    305 Kaupintie 3, Helsinki
+    305 Vanha Maantie 1, Espoo
+    306 Kolmas Linja 17, Helsinki
+    307 Ensi Linja 1, Helsinki
+    308 Aleksanterin teatteri, Helsinki
+    308 Talkoorinne 1, Espoo
+    308 Thalian aukio, Helsinki
+    309 Hotel Sello, Espoo
+    309 Yliopistonkatu 3, Helsinki
+    310 Itäkeskus Library, Helsinki
+    310 Lassila, Helsinki
+    310 Nuijamiestentie 10, Helsinki
+    310 Rörstrandinkatu 3, Helsinki
+    311 Lönnrotinkatu 13, Helsinki
+    311 Revontulenkuja 1, Espoo
+    312 Vironkatu 2, Helsinki
+    313 Kunnalliskodintie 6, Helsinki
+    313 Töölöntullinkatu 8, Helsinki
+    315 Ericsson, Laituri 1, Kirkkonummi
+    315 Kulorastaantie 1, Vantaa
+    315 Käenkuja 3, Helsinki
+    316 Topeliuksenkatu 5, Helsinki
+    317 Viikinkaari 5, Helsinki
+    318 Pähkinärinne, Vantaa
+    319 Fleminginkatu 34, Helsinki
+    319 Jämeräntaival 11, Espoo
+    319 Kallion lukio, Helsinki
+    319 Pasteurinkatu 1, Helsinki
+    320 Urheilutalo, Helsinki
+    321 Nissas, Vantaa
+    322 Hämeentie 161, Helsinki
+    322 Suomenoja, Espoo
+    323 Hakaniemi Square, Helsinki
+    323 Ilmalantori 2, Helsinki
+    323 Isonnevantie 8, Helsinki
+    323 Kaikukatu 4, Helsinki
+    324 Kemistintie 1, Espoo
+    325 Kokkokalliontie 1, Helsinki
+    325 Linnanmäki Amusement Park, Helsinki
+    326 Mäkelänkatu 49, Helsinki
+    327 Erottajanpuiston hostelli, Helsinki
+    327 Ulvilantie 29, Helsinki
+    328 Majurinkulma 2, Espoo
+    328 Vantaanportinkatu 3, Vantaa
+    328 Viljelijäntie 4, Helsinki
+    329 Tammisto, Vantaa
+    330 Kutomokuja 4, Helsinki
+    330 Kuunsilta, Espoo
+    330 Ulvilantie 11, Helsinki
+    331 Kutojantie 1, Espoo
+    331 Ruoholahti metroasema, Helsinki
+    331 Sotungin lukio, Vantaa
+    333 Näyttelijäntie 22, Helsinki
+    333 Tikkurila Park and Ride, Vantaa
+    336 Hotel Sokos Tapiola Garden, Espoo
+    336 Martinlaaksontie 36, Vantaa
+    338 Pasilanraitio 6, Helsinki
+    338 Physicum Kumpula, Helsinki
+    338 Siltakylänkuja 3, Helsinki
+    339 Koskelan sairaala, Helsinki
+    340 Kapteeninkatu 26, Helsinki
+    340 Kauppakorkeakoulut, Helsinki
+    341 Laakson sairaala, Helsinki
+    344 Töölön ala-asteen koulu, Helsinki
+    345 Kantvik, Kirkkonummi
+    345 Keilaniementie 1, Espoo
+    345 Kontula metroasema, Helsinki
+    346 Helsinki-Vantaa lentoasema T1, Laituri 2, Vantaa
+    347 Hanken, Helsinki
+    347 Hämeentie 1, Helsinki
+    347 Lapinrinne 1, Helsinki
+    347 Mäkelänkatu 2, Helsinki
+    347 Väinö Auerin katu 3, Helsinki
+    349 Agricolankatu 1, Helsinki
+    350 Kluuvi, Helsinki
+    350 Opastinsilta 12, Helsinki
+    350 Piispansilta 11, Espoo
+    351 Malmin tori, Helsinki
+    351 Rautalammintie 3, Helsinki
+    353 Espoonlahti, Espoo
+    353 Kuusilahdenkuja 1, Helsinki
+    353 Tapiolansolmu, Espoo
+    354 Siltavuorenpenger 10, Helsinki
+    355 Maininkitie 4, Espoo
+    355 Suvela, Espoo
+    356 Asema-aukio 1, Helsinki
+    356 Kasarmikatu 11-13, Helsinki
+    356 Viikin kampus, Helsinki
+    357 Arkadiankatu 21, Helsinki
+    358 Hesperian puisto, Helsinki
+    358 Kannelmäen asema, Helsinki
+    359 Valimotie 17, Helsinki
+    360 Telakkakatu 8, Helsinki
+    362 Kirstinharju 1, Espoo
+    362 Nikinmäki, Vantaa
+    363 Haartmaninkatu 2, Helsinki
+    363 Riihimäki, -
+    363 Westend, Espoo
+    365 Kylänevantie 16, Helsinki
+    367 Tilanhoitajankaari 11, Helsinki
+    367 Ylioppilastalo, Helsinki
+    369 Katriinan sairaala, Vantaa
+    370 Olympiastadion, Helsinki
+    371 Konemies, Espoo
+    373 Maapadontie 2, Helsinki
+    373 Porkkalankatu 1, Helsinki
+    373 Topeliuksenkatu 41, Helsinki
+    377 Juhana Herttuan tie 3, Helsinki
+    377 Mellunmäki metroasema, Helsinki
+    378 Pihatörmä 1, Espoo
+    379 Hanasaari, Espoo
+    379 Pajamäki, Helsinki
+    379 Siltakuja 2, Espoo
+    380 Pariisinkuja 2, Helsinki
+    380 Pohjoinen Hesperiankatu 17, Helsinki
+    383 Helsinginkatu 1, Helsinki
+    384 Meilahden liikuntapuisto, Helsinki
+    385 Konala, Helsinki
+    385 Mäkelänkatu 84, Helsinki
+    385 Ruskeasuon varikko, Helsinki
+    386 Central Railway Station, Helsinki
+    386 Höyläämötie 1, Helsinki
+    386 Matinniitynkuja 4, Espoo
+    386 Otaniementie 17, Espoo
+    386 Radiokatu 5, Helsinki
+    387 Entresse kauppakeskus, Espoo
+    388 Kaivoksela, Vantaa
+    389 Kilonrinne 10, Espoo
+    393 Lentoasema T2, Vantaa
+    395 Helsinki-Vantaa Airport, Vantaa
+    396 Maapadontie 5, Helsinki
+    397 Jakomäentie 6, Helsinki
+    398 Tennistie 1, Vantaa
+    400 Tyynenmerenkatu 8, Helsinki
+    404 Jätkäsaari, Helsinki
+    405 Hämeentie 153, Helsinki
+    408 Karstulantie 8, Helsinki
+    408 Orionintie 1, Espoo
+    410 Avaruuskatu 3, Espoo
+    410 Hyljeluodontie 3, Espoo
+    410 Olarin lukio, Espoo
+    410 Otakaari 4, Espoo
+    411 Eteläinen Rautatiekatu 4, Helsinki
+    411 Järvenperä, Espoo
+    411 Teollisuuskatu 21, Helsinki
+    412 Kansaneläkelaitos, Helsinki
+    413 Hakaniemenranta 12, Helsinki
+    414 Mankkaa, Espoo
+    415 Arabianranta, Helsinki
+    415 Tuomarilan asema, Espoo
+    418 Linja-autoasema, Helsinki
+    419 Lapinmäentie 1, Helsinki
+    419 Munkkiniemen aukio, Helsinki
+    420 Helsinginkatu 26, Helsinki
+    420 Rautatientori metroasema, Helsinki
+    421 Finlandia-talo, Helsinki
+    426 Helsingin päärautatieasema, Helsinki
+    427 Karhunkierros 1, Vantaa
+    428 Karakaari 7, Espoo
+    429 Käenkuja 1, Helsinki
+    429 Toinen Linja 4, Helsinki
+    431 Hattulantie 1, Helsinki
+    432 Kitarakuja 1, Helsinki
+    433 Latokartanontie 12, Helsinki
+    434 Kaustisenpolku 1, Helsinki
+    434 Talontie 1, Helsinki
+    435 Kutomotie 1, Helsinki
+    435 Suurpelto, Espoo
+    436 WeeGee-talo, Espoo
+    437 Savio, Kerava
+    437 Tukholmankatu 1, Helsinki
+    440 Siltavuorenpenger 5, Helsinki
+    441 Itsehallintotie 1, Espoo
+    441 Jämeräntaival 1, Espoo
+    443 Kaari, Helsinki
+    444 Antti Korpin tie 4, Helsinki
+    444 Mannerheimintie 46, Helsinki
+    445 Helsinginkatu 24, Helsinki
+    446 Muusantori 1, Helsinki
+    449 Juustenintie 3, Helsinki
+    451 Keilaranta 17, Espoo
+    451 Lommila, Espoo
+    451 Pohjolankatu 38, Helsinki
+    452 Espoonlahden uimahalli, Espoo
+    452 Kuninkaantien lukio, Espoo
+    452 Viikinkaari 1, Helsinki
+    453 Munkkiniemen puistotie 1, Helsinki
+    456 Paavalin kirkko, Helsinki
+    456 Westendinasema, Espoo
+    457 Ida Aalbergin tie, Helsinki
+    457 Malmin sairaala, Helsinki
+    458 Ilkantie 4, Helsinki
+    461 Mäkkylä, Espoo
+    463 Westendin asema, Laituri 1, Espoo
+    464 Tapanilan asema, Helsinki
+    466 Jokiniementie 31, Vantaa
+    468 Salmisaari, Helsinki
+    468 Vantaanportti, Vantaa
+    471 Lakelankatu 1, Espoo
+    471 Niittykumpu, Espoo
+    472 Kauppakeskus Kaari, Helsinki
+    473 Porthania, Helsinki
+    474 Kauppakorkeakoulu, Helsinki
+    474 Rälssintie 16, Helsinki
+    476 Kulosaari, Helsinki
+    476 Tikkurilan lukio, Vantaa
+    477 Avaruuskatu 1, Espoo
+    478 Metsänpojankuja 1, Espoo
+    479 Siltavuorenpenger 1, Helsinki
+    479 Välimerenkatu 5, Helsinki
+    481 Mannerheimintie 50, Helsinki
+    481 Tasetie 8, Vantaa
+    482 Itäkeskus metroasema, Helsinki
+    483 Aleksis Kiven katu 1, Helsinki
+    483 Metsänpojankuja 3, Espoo
+    491 Areenankuja 1, Helsinki
+    493 Jan-magnus Janssonin aukio 1, Helsinki
+    493 Klaneettitie 1, Helsinki
+    494 Kumpula, Helsinki
+    496 Postintaival 7, Helsinki
+    496 Takomotie 1, Helsinki
+    497 Ruosilantie 1, Helsinki
+    498 Helsingin asema, Helsinki
+    498 Käpyläntie 1, Helsinki
+    498 Runeberginkatu 14, Helsinki
+    499 Rekola, Vantaa
+    500 Kallio, Helsinki
+    501 Ratapihantie 9, Helsinki
+    502 Bulevardi 31, Helsinki
+    502 Isonnevantie 16, Helsinki
+    508 Ilmala, Helsinki
+    509 Sonera Stadium, Helsinki
+    513 Kettutie 8, Helsinki
+    515 Otakaari 5, Espoo
+    516 Pihlajamäki, Helsinki
+    523 Helsinginkatu 25, Helsinki
+    524 Latokaski, Espoo
+    525 Saunalahti, Espoo
+    530 Valimotie 1, Helsinki
+    531 Akanapolku 2, Vantaa
+    533 Helsinki Railway Station, Helsinki
+    534 Vaskivuoren lukio, Vantaa
+    535 Aleksanterinkatu 1, Helsinki
+    536 Alvar Aallon kuja 1, Helsinki
+    536 Kuusitie 1, Helsinki
+    538 Töölönkatu 51, Helsinki
+    550 Auroran sairaala, Helsinki
+    551 Louhela, Vantaa
+    551 Lääkärinkatu 8, Helsinki
+    554 Karstulantie 6, Helsinki
+    555 Prinsessantie 2, Helsinki
+    556 Itämerenkatu 21, Helsinki
+    562 Vuolukiventie 1, Helsinki
+    564 Pukinmäen asema, Helsinki
+    565 Keilalahdentie 2, Espoo
+    566 Merihaka, Helsinki
+    566 Unioninkatu 40, Helsinki
+    567 Mäkelänrinteen lukio, Helsinki
+    567 Töölön sairaala, Helsinki
+    568 Biomedicum 1, Helsinki
+    569 Huokotie 5, Helsinki
+    572 Kirkkonummen asema, Kirkkonummi
+    572 Mannerheimintie 164, Helsinki
+    572 Tähkäkuja 5, Vantaa
+    578 Viherlaakso, Espoo
+    581 Kevätkatu 2, Helsinki
+    582 Lehtimäki, Espoo
+    583 Haartmaninkatu 8, Helsinki
+    587 Tenholantie 10, Helsinki
+    594 Pitäjänmäen asema, Helsinki
+    595 Gesterby, Kirkkonummi
+    595 Töölön Tulli 2, Helsinki
+    597 Arentikuja 1, Helsinki
+    601 Raumantie 1, Helsinki
+    602 Espoon asema, Espoo
+    603 Kalajärvi, Espoo
+    606 Senaatintori, Helsinki
+    609 Kutojantie 2, Espoo
+    612 Aapelinkatu 5, Espoo
+    616 Viikinkaari 11, Helsinki
+    624 Keran asema, Espoo
+    627 Leppävaara Park and Ride south, Espoo
+    629 Karakallio, Espoo
+    629 Nordenskiöldinkatu 1, Helsinki
+    636 Valimo, Helsinki
+    638 Koivuhovi liityntäpysäköinti, Espoo
+    640 Porvoonkatu 1, Helsinki
+    641 Tilkka, Helsinki
+    641 Töölöntullinkatu 6, Helsinki
+    643 Vanha Maantie 9, Espoo
+    644 Santahamina, Helsinki
+    645 Näätätie 20, Helsinki
+    654 Karhupuisto, Helsinki
+    665 Naistenklinikka, Helsinki
+    665 Viiskulman terveysasema, Helsinki
+    666 Väinö Auerin katu 1, Helsinki
+    669 Siilitie liityntäpysäköinti, Helsinki
+    669 Vantaankoski liityntäpysäköinti, Vantaa
+    671 Valimotie 8, Helsinki
+    681 Energiakatu 3, Helsinki
+    684 Linnoituksentie 10, Helsinki
+    685 Suomenlinna, Helsinki
+    694 Forum, Helsinki
+    694 Olari, Espoo
+    695 Sibeliuksenkatu 14, Helsinki
+    697 Helsinki keskusta, Helsinki
+    698 Rantaharju 10, Espoo
+    701 Musiikkitalo, Helsinki
+    702 Ida Aalbergin tie 1, Helsinki
+    703 Piispansilta 3, Espoo
+    704 Kamppi metroasema, Helsinki
+    711 Tyynenmerenkatu 11, Helsinki
+    715 Sörnäinen metroasema, Helsinki
+    718 Kulttuuritalo, Helsinki
+    724 Hyvinkää, -
+    729 Arcada, Helsinki
+    729 Jakomäki, Helsinki
+    731 Peijaksen sairaala, Vantaa
+    731 Viikin tiedepuisto, Helsinki
+    739 Peltokyläntie 3, Helsinki
+    741 Heikintori, Espoo
+    741 Peijas Hospital, Vantaa
+    743 Käpylän asema, Helsinki
+    747 Söderkulla, Sipoo
+    748 0
+    750 Kätilöopisto, Helsinki
+    753 Ikea Vantaa, Vantaa
+    757 Pasila Railway Station, Helsinki
+    762 Innopoli, Espoo
+    762 Sturenkatu 4, Helsinki
+    769 Messuaukio 1, Helsinki
+    783 Fabianinkatu 33, Helsinki
+    787 Alvar Aallon puisto, Espoo
+    787 Vanha Viertotie 23, Helsinki
+    789 Pasilanraitio 11, Helsinki
+    789 Vuosaari metroasema, Helsinki
+    790 Iivisniemi, Espoo
+    792 Alppikatu 2, Helsinki
+    799 Katajanokan terminaali, Helsinki
+    803 Oulunkylän asema, Helsinki
+    804 Tennispalatsi, Helsinki
+    808 Hattulantie 2, Helsinki
+    809 Munkkivuori, Helsinki
+    811 Tallberginkatu 1, Helsinki
+    813 Barona Areena, Espoo
+    818 Käpylä, Helsinki
+    828 Koivukylän asema, Vantaa
+    836 Kirkkokatu 16, Espoo
+    838 Hiekkaharju, Vantaa
+    841 Huopalahden asema, Helsinki
+    841 Lintukorventie 2, Espoo
+    847 Mikkola, Vantaa
+    850 Sturenkatu 2, Helsinki
+    860 Mäkelänrinne indoor swimming centre, Helsinki
+    866 Meilahti, Helsinki
+    867 Haartmaninkatu 1, Helsinki
+    867 Teekkarikylä, Espoo
+    868 Veikkola, Kirkkonummi
+    875 Munkkiniemi, Helsinki
+    882 Jäähalli, Helsinki
+    884 Makasiiniterminaali, Helsinki
+    885 Puustellinmäki, Espoo
+    885 Rastila, Helsinki
+    890 Läntinen Brahenkatu 2, Helsinki
+    895 Katajanokka, Helsinki
+    896 Puistolan asema, Helsinki
+    900 Lähderanta, Espoo
+    912 Hakaniemen tori, Helsinki
+    912 Kisahalli, Helsinki
+    915 Kaupinkalliontie 3, Espoo
+    916 Nihtisilta, Espoo
+    923 Pohjois-Haaga, Helsinki
+    943 Meilahdentie 2, Helsinki
+    952 Nikkilä, Sipoo
+    962 Lehtimäentie 1, Espoo
+    967 Myyrmanni, Vantaa
+    971 Mannerheimintie 1, Helsinki
+    973 Kuusitie 5, Helsinki
+    992 Mistelitie 26, Vantaa
+    998 Ruskeasuo, Helsinki
+   1020 Lauttasaari, Helsinki
+   1020 Sofianlehdonkatu 5, Helsinki
+   1022 Vanha Maantie 6, Espoo
+   1027 Konemiehentie 2, Espoo
+   1046 Matinkylä, Espoo
+   1057 Puotila, Helsinki
+   1065 Kauppatori, Helsinki
+   1069 Helsingin jäähalli, Helsinki
+   1091 Hakunila, Vantaa
+   1098 Soukka, Espoo
+   1099 Kiasma, Helsinki
+   1107 Espoontori, Espoo
+   1109 Kalasatama metroasema, Helsinki
+   1121 Stockmann, Helsinki
+   1124 Jorvin sairaala, Espoo
+   1131 Korson asema, Vantaa
+   1133 Kurvi, Helsinki
+   1157 Pajuniityntie 11, Helsinki
+   1177 Martinlaakson asema, Vantaa
+   1188 Ikea Espoo, Espoo
+   1189 Itis, Helsinki
+   1191 Tapanila, Helsinki
+   1210 Tivolikuja 1, Helsinki
+   1220 Olympiaterminaali, Helsinki
+   1229 Flamingo, Vantaa
+   1251 Kampin keskus, Helsinki
+   1258 Leiritie 1, Vantaa
+   1262 Kaivokatu 1, Helsinki
+   1277 Teollisuuskatu 23, Helsinki
+   1279 Otakaari 1, Espoo
+   1296 Railway Station, Helsinki
+   1327 Töölöntori, Helsinki
+   1341 Kivenlahti, Espoo
+   1347 Töölönkatu 37, Helsinki
+   1354 Herttoniemi metroasema, Helsinki
+   1366 Ratapihantie 13, Helsinki
+   1366 Ruusutorpantie 4, Espoo
+   1366 Tuomarila, Espoo
+   1381 Meilahden sairaala, Helsinki
+   1396 Albertinkatu 32, Helsinki
+   1397 Myyrmäen asema, Vantaa
+   1412 Arabia, Helsinki
+   1423 Maunula, Helsinki
+   1444 Oulunkylä, Helsinki
+   1445 Kantelettarentie 1, Helsinki
+   1458 Rautatientori Metro Station, Helsinki
+   1460 Gustaf Hällströmin katu 2, Helsinki
+   1462 Masala, Kirkkonummi
+   1471 Espoo, Espoo
+   1498 Jorvi, Espoo
+   1533 Lippulaiva, Espoo
+   1566 Haartmaninkatu 4, Helsinki
+   1572 Myllypuro, Helsinki
+   1594 Oopperatalo, Helsinki
+   1595 Järvenpää, -
+   1611 Pitäjänmäki, Helsinki
+   1630 Lasipalatsi, Helsinki
+   1634 Mannerheimintie 172, Helsinki
+   1640 Keravan asema, Kerava
+   1646 Huopalahti liityntäpysäköinti, Helsinki
+   1716 Malminkartano, Helsinki
+   1735 Töölön kisahalli, Helsinki
+   1783 Tukholmankatu 10, Helsinki
+   1849 Airport, Vantaa
+   1883 Länsiterminaali, Helsinki
+   1886 Katajanokanlaituri 6, Helsinki
+   1928 Dipoli, Espoo
+   1963 Puistola, Helsinki
+   1966 Keskusta, Helsinki
+   1978 Hämeentie 135, Helsinki
+   2085 Kauklahti, Espoo
+   2143 Martinlaakso, Vantaa
+   2201 Kannelmäki, Helsinki
+   2213 Keskuskatu 2, Helsinki
+   2228 Kilo, Espoo
+   2259 Pukinmäki, Helsinki
+   2287 Kaapelitehdas, Helsinki
+   2289 Viikki, Helsinki
+   2305 Opastinsilta 8, Helsinki
+   2343 Leppävaaran asema, Espoo
+   2347 Malmin asema, Helsinki
+   2360 Linnankatu 9, Helsinki
+   2443 Steissi, Helsinki
+   2516 Kauniainen, Kauniainen
+   2530 Kumpulan kampus, Helsinki
+   2532 Kontula, Helsinki
+   2547 Länsisatama, Helsinki
+   2603 Koivukylä, Vantaa
+   2791 Vuosaari, Helsinki
+   2807 Kamppi terminal, Helsinki
+   2886 Lentokenttä, Vantaa
+   2912 Kaisaniemi metroasema, Helsinki
+   3025 Helsinki-Vantaan lentoasema, Vantaa
+   3064 Messukeskus, Helsinki
+   3095 Hartwall Areena, Helsinki
+   3268 Ruoholahti, Helsinki
+   3271 Mellunmäki, Helsinki
+   3376 Otaniemi, Espoo
+   3622 Helsingin rautatieasema, Helsinki
+   3997 Kirkkonummi, Kirkkonummi
+   4112 Kerava, Kerava
+   4118 Tapiola, Espoo
+   4483 Korso, Vantaa
+   4666 Herttoniemi, Helsinki
+   4967 Jumbo, Vantaa
+   5003 Tikkurilan asema, Vantaa
+   5415 Lentoasema, Vantaa
+   5710 Myyrmäki, Vantaa
+   6356 Hakaniemi metroasema, Helsinki
+   7111 Iso Omena, Espoo
+   7568 Malmi, Helsinki
+   7670 Espoon keskus, Espoo
+   7969 Sörnäinen, Helsinki
+   8348 Sello, Espoo
+   8852 Pasilan asema, Helsinki
+   9984 Itäkeskus, Helsinki
+  10428 Elielinaukio, Helsinki
+  12949 Tikkurila, Vantaa
+  14675 Pasila, Helsinki
+  15952 Leppävaara, Espoo
+  23350 Helsinki, Helsinki
+  26261 Rautatieasema, Helsinki
+  27350 Rautatientori, Helsinki
+  43341 Kamppi, Helsinki

--- a/endpoints_custom_hsl.csv
+++ b/endpoints_custom_hsl.csv
@@ -1,0 +1,2904 @@
+name,lat,lon
+"Mattilan päiväkoti, Tuusula",60.412161,25.071417
+"Karakalliontie 14, Espoo",60.230409,24.765385
+"Mäntytie 1, Helsinki",60.191634,24.901802
+"Pengerkatu 22, Helsinki",60.187023,24.959144
+"Katontekijänkuja 1, Helsinki",60.252831,25.022475
+"Pihkatie 5, Helsinki",60.251844,24.854865
+"Hämeentie, Helsinki",60.198494,24.961933
+"Hämeentie 28, Helsinki",60.183331,24.957985
+"Pitäjänmäentie 13, Helsinki",60.224203,24.861891
+"Jönsaksentie 6, Vantaa",60.261808,24.855063
+"Pähkinätie 3, Vantaa",60.265007,24.803471
+"Pengerkatu 21, Helsinki",60.185816,24.95959
+"Herttoniemi(M), 4040, Helsinki",60.195048,25.030868
+"Isonvillasaarentie 1, Helsinki",60.220968,25.145916
+"Ruotsinpiha 2, Vantaa",60.286101,24.958561
+"Porvoonkatu 25, Helsinki",60.191526,24.944235
+"Roihuvuorentie 30, Helsinki",60.202921,25.059061
+"Scandic Park Helsinki, Helsinki",60.178945,24.92796
+"Sellosali, Espoo",60.217642,24.808221
+"Samis, Ka1708, Kauniainen",60.21386,24.720831
+"Tehtaankatu 25, Helsinki",60.158061,24.935694
+"Sörnäistenkatu 1, Helsinki",60.189446,24.969527
+"Taimistontie 2, Helsinki",60.218032,24.866878
+"Vaakatie 1, Vantaa",60.253199,24.820022
+"Vaasankatu 9, Helsinki",60.188467,24.959
+"Teknikontie 7, Vantaa",60.310904,24.958244
+"Ilmalantori 1, Helsinki",60.206948,24.916597
+"Alakiventie 1, Helsinki",60.222771,25.075726
+"Huopalahdentie 24, Helsinki",60.208107,24.878713
+"Itsehallintokuja 6, Espoo",60.209667,24.82636
+"Hitsaajankatu 9, Helsinki",60.192341,25.029237
+"Huopalahdentie 3, Helsinki",60.197527,24.884953
+"Itäviitta 1, Espoo",60.166308,24.614824
+"Klippinkitie 1, Espoo",60.191724,24.597627
+"Kivikko, Helsinki",60.242773,25.064958
+"Koudantie 2, Helsinki",60.267222,25.056103
+"Koskelantie 23, Helsinki",60.211301,24.954459
+"Hämeentie 95, Helsinki",60.197236,24.962713
+"Kaisaniemenkatu 3, Helsinki",60.171128,24.947133
+"Kaarlenkatu 15, Helsinki",60.186725,24.952057
+"Opettajantie 3, Espoo",60.144638,24.664583
+"Perhonkatu 1, Helsinki",60.170014,24.925228
+"Neljäs Linja 26, Helsinki",60.184345,24.946849
+"Maasälväntie 16, Helsinki",60.238611,25.012169
+"Lauttasaarentie 32, Helsinki",60.160171,24.879893
+"Kuunkehrä, Espoo",60.173181,24.725779
+"Niittykummuntie 6, Espoo",60.16898,24.757572
+"Pohjois-Tapiolan koulu ja lukio, Espoo",60.187195,24.790872
+"Rosendalinrinki 1, Vantaa",60.268747,24.967815
+"Pietarinkatu 1, Helsinki",60.158398,24.952162
+"Pyhtäänkorventie 21, Vantaa",60.300572,24.975051
+"Riiantie 1, Espoo",60.187539,24.592701
+"Kuortaneenkatu 7, Helsinki",60.196333,24.944331
+"Riistavuorenkuja 8, Helsinki",60.21942,24.885745
+"Sammalkalliontie 6, Espoo",60.176184,24.734812
+"Sibelius-lukio, Helsinki",60.174539,24.956314
+"Säterinkatu 8, Vantaa",60.269018,24.962406
+"Talonpojantie 25, Helsinki",60.226906,25.023424
+"Sturenkatu 26, Helsinki",60.194147,24.955761
+"Taavetti Laitisen Katu 1, Helsinki",60.19879,24.897122
+"Vallilan varikko, Helsinki",60.196701,24.962475
+"Tammistonkatu 27, Vantaa",60.273324,24.96348
+"Takkatie 7, Helsinki",60.222942,24.854811
+"Yrjönkatu 21, Helsinki",60.168053,24.939034
+"Vaijeritie 1, Vantaa",60.254885,24.808975
+"Talvelantie 4, Helsinki",60.253896,25.001266
+"Arinatie 20, Vantaa",60.282928,24.965976
+"Backåkersvägen 19, Helsingfors",60.220744,24.898406
+"Alppila, Helsinki",60.189893,24.942922
+"Espoontie 25, Espoo",60.219861,24.664632
+"Brinkinmäentie 1, Espoo",60.169549,24.615761
+"Apollonkatu, Helsinki",60.176424,24.922296
+"Bulevardi 40, Helsinki",60.162548,24.932583
+"Hagelstamintie 20, Vantaa",60.281697,24.960717
+"Hietaniemenkatu 1, Helsinki",60.169971,24.925879
+"Hämeentie 26, Helsinki",60.18311,24.957043
+"Hämeentie 70, Helsinki",60.191015,24.964055
+"Huopalahdentie 1, Helsinki",60.196779,24.885921
+"Näyttelijäntie, Helsinki",60.227882,24.894615
+"Mestarintie 5, Vantaa",60.30532,24.851848
+"Kutomotie 6, Helsinki",60.213822,24.874372
+"Helsingin Kaupunginteatteri, Helsinki",60.181805,24.94262
+"Malminkartanontie 1, Helsinki",60.244,24.847519
+"Kirstintie 17, Espoo",60.204256,24.673195
+"Karapellontie 11, Espoo",60.217195,24.75103
+"Tenholantie 1, Helsinki",60.20279,24.901883
+"Mustialankatu 1, Helsinki",60.230028,25.02199
+"Reiherintie 7, Helsinki",60.169248,25.042535
+"Töölönkatu 27, Helsinki",60.180343,24.925153
+"Stoa, Helsinki",60.211934,25.07918
+"Vanha Yrttimaantie 22, Helsinki",60.268709,25.013417
+"Heikinlaaksontie, Helsinki",60.269854,25.069296
+"Veromäen koulu, Vantaa",60.286159,24.962077
+"Unioninkatu 39, Helsinki",60.174338,24.950827
+"Vanamonkuja 1, Vantaa",60.308121,25.026664
+"Kaisaniemenkatu, Helsinki",60.171765,24.947675
+"Vattuniemenkatu 16, Helsinki",60.152686,24.884151
+"Hirsalantie 11, Kirkkonummi",60.130741,24.514072
+"Vieraskuja, Espoo",60.207492,24.661783
+"Hirsipadontie 5, Helsinki",60.23409,24.95172
+"Kirjurinkuja 1, Espoo",60.215942,24.826179
+"Kluuvikatu 1, Helsinki",60.168337,24.947884
+"Fredrikinkatu 48, Helsinki",60.169401,24.929106
+"Hämeentie 36, Helsinki",60.184479,24.959573
+"Karjalankatu 2, Helsinki",60.193159,24.936611
+"Katajanokanlaituri 1, Helsinki",60.167899,24.958492
+"Käpyläntie 4, Helsinki",60.214439,24.958216
+"Linnoitustie 6, Espoo",60.210938,24.814092
+"Metsänhoitajankatu, Helsinki",60.233496,25.04357
+"Mannerheimintie, Helsinki",60.187618,24.919099
+"Nuolikuja 6, Vantaa",60.298639,24.911123
+"Makasiiniterminaali, Helsinki",60.163914,24.954801
+"Koivu-Mankkaan tie 5, Espoo",60.176666,24.782595
+"Katariina Saksilaisen katu, Helsinki",60.216688,24.984894
+"Otaranta 6, Espoo",60.184296,24.834837
+"Kutomotie 12, Helsinki",60.214763,24.87039
+"Mannerheimintie 47, Helsinki",60.188811,24.918179
+"Vattuniemenranta 2, Helsinki",60.154289,24.886741
+"Pursimiehenkatu 25, Helsinki",60.15892,24.936055
+"Siltavoudintie 1, Helsinki",60.22925,24.965241
+"Simonkallion koulu, Vantaa",60.307161,25.024024
+"Porslahdentie, Helsinki",60.222172,25.149255
+"Pasilanraitio 12, Helsinki",60.200973,24.925095
+"Vuorikatu 14, Helsinki",60.171654,24.946883
+"Sotungintie 19, Vantaa",60.2802,25.12162
+"Siltasaarenkatu 15, Helsinki",60.182505,24.949831
+"Vantaanpuisto, Vantaa",60.300195,24.85388
+"Valimotie 16, Helsinki",60.22012,24.876709
+"Hagelstamintie 27, Vantaa",60.280155,24.968482
+"Kamreerintie 2, Espoo",60.203513,24.653955
+"Aalto 6, Espoo",60.149527,24.639391
+"Asema-aukio 2, Helsinki",60.170488,24.938321
+"Helsinginkatu 14, Helsinki",60.186885,24.954301
+"Horsmakuja 4, Helsinki",60.202791,25.082201
+"Kaivosrinteenkuja 2, Vantaa",60.270214,24.872251
+"Kansallisteatteri, Helsinki",60.172401,24.943819
+"Kaskenkaatajantie 1, Espoo",60.181941,24.793892
+"Kurkisuontie 12, Helsinki",60.233038,25.072089
+"Länsisatamankatu 16, Helsinki",60.159373,24.909932
+"Linnatullinkatu 1, Espoo",60.218871,24.80822
+"Korppaanmäentie 17, Helsinki",60.205582,24.892735
+"Myyrmäentie 2, Vantaa",60.264619,24.852782
+"Niittymaantie 1, Espoo",60.170088,24.775308
+"Maununnevantie 1, Helsinki",60.24392,24.900228
+"Mechelininkatu 15, Helsinki",60.172398,24.9203
+"Osmontie 34, Helsinki",60.219114,24.946263
+"Pikku Satamakatu 3, Helsinki",60.165633,24.967645
+"Töyrytie 6, Helsinki",60.226163,24.924839
+"Vääksyntie 4, Helsinki",60.190834,24.961054
+"Toinen Linja 10, Helsinki",60.183461,24.942557
+"Ylistörmä 5, Espoo",60.176077,24.738065
+"Urheilupuistontie 2, Espoo",60.178776,24.787253
+"Pohjantori, E2051, Espoo",60.1836,24.79511
+"Untamontie 15, Helsinki",60.212688,24.955329
+"Untamontie 10, Helsinki",60.213164,24.952971
+"Tanhuantie 1, Helsinki",60.236131,25.094106
+"Wallininkuja 3, Helsinki",60.184958,24.945241
+"Vyökatu 1, Helsinki",60.166666,24.969401
+"Emma - Espoon modernin taiteen museo, Espoo",60.178754,24.794426
+"Jämeräntaival 3, Espoo",60.187339,24.836368
+"Käskynhaltijantie 14, Helsinki",60.23608,24.973668
+"Malmin Kauppatie 8, Helsinki",60.249799,25.006576
+"Kuurinniitty, Espoo",60.197777,24.700396
+"Keijumäki 1, Espoo",60.18872,24.799679
+"Haapaniemenkatu 12, Helsinki",60.180017,24.960913
+"Kiltakuja 1, Espoo",60.199661,24.654609
+"Munkkiniemen Puistotie 25, Helsinki",60.199215,24.873639
+"Peshawar, Espoo",60.209874,24.754144
+"Pallomylly, Helsinki",60.21935,25.079587
+"Nuijavuori 1, Espoo",60.211466,24.767072
+"Läkkisepänkuja 8, Helsinki",60.220523,24.937527
+"Runeberginkatu 32, Helsinki",60.176157,24.921739
+"Pukinkuja 2, Helsinki",60.250655,24.982978
+"Kuusitie 11, Helsinki",60.19473,24.897707
+"Otavantie 1, Helsinki",60.156649,24.879273
+"Startup Sauna, Espoo",60.180562,24.832284
+"Pasilan kirjasto, Helsinki",60.200775,24.935879
+"Talttakuja 1, Helsinki",60.242117,25.025
+"Sampsantie 50, Helsinki",60.217311,24.94587
+"Urheilukatu 9, Helsinki",60.190308,24.918535
+"Teknillinen korkeakoulu, Espoo",60.187185,24.827666
+"Tukholmankatu 2, Helsinki",60.190748,24.911725
+"Soukantie 16, Espoo",60.141712,24.66978
+"Arabiankatu 12, Helsinki",60.209273,24.978625
+"Allergia-apu, Helsinki",60.195835,24.960099
+"Tapiolan terveysasema, Espoo",60.178288,24.798093
+"Juvanpuro 1, Espoo",60.277818,24.752095
+"Isokaari 9, Helsinki",60.157183,24.868355
+"Arabiankatu 6, Helsinki",60.207493,24.977294
+"Haapaniemenkatu 11, Helsinki",60.179039,24.959784
+"Isonnevantie 28, Helsinki",60.217104,24.886923
+"Ensi Linja 2, Helsinki",60.181851,24.942424
+"Liuskekuja 1, Helsinki",60.236222,25.018744
+"Mannerheimintie 81, Helsinki",60.19319,24.908774
+"Kaskilaaksontie 1, Espoo",60.139443,24.660845
+"Kaupintie 11, Helsinki",60.231135,24.881342
+"Kaikukatu 2, Helsinki",60.183027,24.95923
+"Kivikonkaari 49, Helsinki",60.232117,25.057027
+"Krakankuja 2, Vantaa",60.288622,24.944979
+"Mäkitorpantie 30, Helsinki",60.226648,24.954857
+"Länsisatamankatu 23, Helsinki",60.158222,24.910419
+"Läntinen Papinkatu, Helsinki",60.184604,24.948679
+"Paciuksenkatu 29, Helsinki",60.195544,24.890673
+"Nelikkokuja 1, Espoo",60.161654,24.7414
+"Vanha Nurmijärventie, Vantaa",60.28056,24.875099
+"Postipuuntie 10, Espoo",60.22238,24.823297
+"Merenkulkijankatu 1, Espoo",60.147446,24.656727
+"Vallikatu, Espoo",60.228212,24.81895
+"Vaisalantie 8, Espoo",60.188772,24.808225
+"Vanha Viertotie 22, Helsinki",60.211793,24.880045
+"Snellmaninkatu 1, Helsinki",60.169808,24.954714
+"Vattuniemen Puistotie 1, Helsinki",60.151627,24.891596
+"Siltasaarenkatu 13, Helsinki",60.181689,24.949918
+"Vesikuja 8, Helsinki",60.196408,24.893631
+"Westendintie 99, Espoo",60.162875,24.791422
+"Hansakallio 2, Espoo",60.188713,24.594058
+"Erottajankatu, Helsinki",60.165423,24.944007
+"Hämeentie 67, Helsinki",60.194021,24.9645
+"Juustenintie 1, Helsinki",60.244758,24.869404
+"Alppikatu 9, Helsinki",60.185297,24.943398
+"Hämeentie 44, Helsinki",60.185914,24.960602
+"Annankatu 18, Helsinki",60.165513,24.937804
+"Eteläinen Rautatiekatu, Helsinki",60.170228,24.93002
+"Kalevankatu, Helsinki",60.162834,24.92483
+"Kala-Maija 3, Espoo",60.15937,24.740169
+"Käskynhaltijantie 11, Helsinki",60.234658,24.959993
+"Käskynhaltijantie, Helsinki",60.237628,24.975655
+"Pohjantie 2, Espoo",60.175006,24.798162
+"Kiviteltankatu 1, Helsinki",60.229634,24.996369
+"Piilipuuntie 7, Espoo",60.185961,24.739838
+"Linnoitustie 9, Espoo",60.212193,24.811229
+"Huutokonttori, Helsinki",60.159741,24.92108
+"Tammihaantie 2, Espoo",60.233487,24.718267
+"Tietotie 6, Espoo",60.183853,24.819338
+"Vilppulantie 1, Helsinki",60.248396,25.011233
+"Pikku Huopalahti, Helsinki",60.204534,24.889584
+"Rasinkatu 4, Vantaa",60.322319,25.064418
+"Fabianinkatu 1, Helsinki",60.163278,24.951227
+"Jokiniemi, Vantaa",60.298265,25.056779
+"Huopalahdentie 10, Helsinki",60.198856,24.883189
+"Maapallonkatu 8, Espoo",60.170968,24.726085
+"Leenankuja, Espoo",60.153628,24.741334
+"Järnvägstorget, Helsingfors",60.171283,24.942572
+"Majurinkulma, Espoo",60.211559,24.825847
+"Kutomotie 16, Helsinki",60.215633,24.86967
+"Mäkelänkatu 54, Helsinki",60.196815,24.950508
+"Rautatieläisenkatu 1, Helsinki",60.202179,24.939039
+"Mekaanikonkatu 1, Helsinki",60.199873,25.042353
+"Kuusikkotie 4, Helsinki",60.230334,24.927302
+"Neitsytsaarentie 1, Helsinki",60.222304,25.139937
+"Keravan aurinkovoimala, Kerava",60.422788,25.125042
+"Kirkkojärventie 6, Espoo",60.205621,24.655357
+"Pertunpellontie 1, Helsinki",60.268254,24.992128
+"Ristiaallokonkatu 4, Espoo",60.154028,24.642401
+"Satulamaakarintie 1, Espoo",60.190294,24.619902
+"Solnantie 19, Helsinki",60.195012,24.878169
+"Säterintie 2, Helsinki",60.243172,24.993555
+"Sakara 2, Helsinki",60.243729,25.079121
+"Sauvatie, Vantaa",60.31977,25.073512
+"Fabianinkatu 7, Helsinki",60.164216,24.950322
+"Taivaskalliontie 1, Helsinki",60.219374,24.960202
+"Tapanilankaari, Helsinki",60.267032,25.031848
+"Töölönkatu 3, Helsinki",60.174019,24.931483
+"Asemakuja 3, Espoo",60.205033,24.660218
+"Gyldenintie 2, Helsinki",60.158518,24.876438
+"Helsinginkatu 20, Helsinki",60.186725,24.952057
+"Hämeentie 30, Helsinki",60.183581,24.95842
+"Hernesaari, Helsinki",60.148743,25.098482
+"Itämerenkatu 8, Helsinki",60.1633,24.918027
+"Sörnäisten rantatie 23, Helsinki",60.184963,24.965714
+"Katajaharjuntie 1, Helsinki",60.16405,24.859168
+"Komeetankatu 2, Espoo",60.166378,24.733955
+"Kirstinkatu 4, Helsinki",60.186063,24.946434
+"Laivalahdenkaari 34, Helsinki",60.186243,25.032903
+"Lohkopellontie 1, Helsinki",60.224325,24.966214
+"Kuuluttajankatu 1, Helsinki",60.205584,24.916683
+"Unikkotie 3, Helsinki",60.245968,24.990782
+"Lummetie 5, Vantaa",60.296515,25.040502
+"Maununnevantie 3, Helsinki",60.243707,24.901524
+"Rasinkatu 15, Vantaa",60.3241,25.066468
+"Upseerinkatu 3, Espoo",60.216151,24.818655
+"Piispansilta, Espoo",60.160398,24.73769
+"Runeberginkatu 61, Helsinki",60.180343,24.925153
+"Tähkätie 4, Helsinki",60.234461,24.850818
+"Ulvilantie 1, Helsinki",60.205373,24.879575
+"Heinjoenpolku 2, Espoo",60.203414,24.802286
+"Lehdeskuja 1, Espoo",60.182709,24.667741
+"Porvoonkatu 19, Helsinki",60.190915,24.946564
+"Olympiakylä, 3061, Helsinki",60.210898,24.952538
+"Postitalo, Helsinki",60.170971,24.937039
+"Nihtisilta 4, Espoo",60.207219,24.749601
+"Henttaa, Espoo",60.192543,24.730731
+"Ressun lukio, Helsinki",60.167059,24.938156
+"Helsinki",60.172992,24.942044
+"Trumpettitie 6, Helsinki",60.238822,24.868381
+"Adjutantinkatu 8, Espoo",60.223239,24.83458
+"Suursuonlaita 2, Helsinki",60.234154,24.93611
+"Tuukkalantie 15, Helsinki",60.242407,25.100841
+"Munkkiniemen Puistotie 17, Helsinki",60.198138,24.87822
+"Junkkarinkaari 7, Vantaa",60.288801,24.961233
+"Valimotie, Helsinki",60.216789,24.877451
+"Satamaradankatu 5, Helsinki",60.190473,24.954583
+"Äyritie 1, Vantaa",60.294477,24.976478
+"Hiomotie 46, Helsinki",60.219599,24.869376
+"Rautalammintie 1, Helsinki",60.196641,24.956129
+"Iivisniemenkatu 4, Espoo",60.149207,24.69051
+"Isonniitynkuja 2, Espoo",60.163593,24.706804
+"Hämeentie 34, Helsinki",60.184165,24.959069
+"Isonnevantie 1, Helsinki",60.210648,24.888746
+"Kaivokselantie 8, Vantaa",60.266991,24.871267
+"Nuumäki, E1401, Espoo",60.23675,24.74327
+"Näyttelijäntie 16, Helsinki",60.231597,24.896321
+"Laivalahdenkaari 19, Helsinki",60.187126,25.035537
+"Olarinniityntie 4, Espoo",60.18063,24.735894
+"Erottajankatu 5, Helsinki",60.164715,24.944811
+"Leppävaarankatu 1, Espoo",60.217572,24.81273
+"Maarukankuja 1, Vantaa",60.337781,25.103453
+"Otsolahdentie 16, Espoo",60.177535,24.818044
+"Toivonkatu, Helsinki",60.184195,24.924781
+"Töölön Yhteiskoulu, Helsinki",60.185282,24.923824
+"Mannerheimintie 113, Helsinki",60.206637,24.899724
+"Raiviosuonmäki 3, Vantaa",60.280988,24.846336
+"Soidinkuja 6, Helsinki",60.252876,25.017069
+"Sahaajankatu 20, Helsinki",60.200056,25.046853
+"Tietotie 2, Espoo",60.185374,24.822213
+"Vanha Tapanilantie 62, Helsinki",60.262323,25.012774
+"Tehtaankatu, Helsinki",60.158196,24.94469
+"Viipurinkatu 4, Helsinki",60.190489,24.947421
+"Castréninkatu 28, Helsinki",60.185695,24.950533
+"Viulutie 1, Helsinki",60.236826,24.880577
+"Kaivokatu 6, Helsinki",60.170036,24.942171
+"Kastanjakuja, Vantaa",60.256552,24.803895
+"Honkavaarankuja 1, Espoo",60.230082,24.734993
+"Antaksentie 3, Vantaa",60.292633,24.945289
+"Vuorenpeikontie 5, Helsinki",60.201626,25.055871
+"Hämeentie 3, Helsinki",60.18072,24.952917
+"Huokotie 1, Helsinki",60.261487,25.075828
+"Kielotie 7, Vantaa",60.290003,25.03626
+"Kluuvikatu 3, Helsinki",60.168642,24.947847
+"Lontoonkatu 9, Helsinki",60.203073,24.973774
+"Miestentie 2, Espoo",60.179369,24.826884
+"Lokkalantie 14, Helsinki",60.199117,24.87987
+"Merituulentie 30, Espoo",60.170762,24.772125
+"Museokatu 10, Helsinki",60.174019,24.931483
+"Kivivuorentie 4, Vantaa",60.278362,24.853924
+"Porintie 5, Helsinki",60.205779,24.870164
+"Teknobulevardi 1, Vantaa",60.305686,24.970866
+"Mäkelänkatu 30, Helsinki",60.194441,24.956176
+"Sokerilinnantie 11, Espoo",60.21555,24.815446
+"Pirkkolan Uimahalli, Helsinki",60.231977,24.910778
+"Haapaniemistigen 15, Kyrkslätt",60.234346,24.365658
+"Vanamontie 4, Vantaa",60.307995,25.029677
+"Ateneum, Helsinki",60.170018,24.944089
+"Yrjönkatu 18, Helsinki",60.165628,24.941726
+"Everstinkuja 1, Espoo",60.212762,24.822834
+"Helsinge skola, Vantaa",60.281924,24.981057
+"Esikkotie 9, Vantaa",60.298559,25.043944
+"Viljo Sohkasen Katu 3, Vantaa",60.29784,25.051244
+"Kaivopuisto, Helsinki",60.159617,24.95463
+"Kaanaanpiha 4, Helsinki",60.212394,24.980689
+"Temppeliaukion kirkko, Helsinki",60.172953,24.925227
+"Katajanokanranta 1, Helsinki",60.165377,24.972022
+"Hakaniemenkatu 7, Helsinki",60.178971,24.954775
+"Kiskottajankuja 1, Espoo",60.22955,24.814117
+"Karhutie 1, Kirkkonummi",60.127201,24.471827
+"Kirvisenkuja 1, Vantaa",60.365669,25.069156
+"Kuusitie 12, Helsinki",60.194131,24.898449
+"Karhulantie 2, Helsinki",60.215716,25.104714
+"Kasöörinkatu 3, Helsinki",60.198631,24.942528
+"Kruununhaka, Helsinki",60.173005,24.953536
+"Kontulankaari 24, Helsinki",60.246296,25.080236
+"Konalantie 12, Helsinki",60.226828,24.85204
+"Opastinsilta 8, Helsinki",60.198971,24.939272
+"Lönnrotinkatu 41, Helsinki",60.162698,24.927221
+"Jupperin koulu, Espoo",60.249012,24.769721
+"Mannerheimintie 120, Helsinki",60.192271,24.909211
+"Siilitie 18, Helsinki",60.212932,25.038669
+"Löydöstie 1, Vantaa",60.262694,24.857608
+"Raikurinne 1, Vantaa",60.277398,24.863754
+"Mikkelä, Espoo",60.204998,24.635395
+"Yläkiventie 5, Helsinki",60.222557,25.070881
+"Sibeliuksenkatu 10, Helsinki",60.181958,24.922238
+"Peltokyläntie, Helsinki",60.268678,24.982448
+"Unioninkatu 20, Helsinki",60.165999,24.950571
+"Hakaniemenranta 1, Helsinki",60.177745,24.950993
+"Gyldenintie 6, Helsinki",60.160334,24.877154
+"Betonimiehenkuja 3, Espoo",60.180546,24.831856
+"Kuitinmäen koulu, Espoo",60.168173,24.726736
+"Hämeentie 124, Helsinki",60.205114,24.96975
+"Vanha Viertotie 2, Helsinki",60.209149,24.888807
+"Kirstinkatu 2, Helsinki",60.185577,24.946393
+"Koivuvaarankuja 1, Vantaa",60.255316,24.817152
+"Vanha Turuntie 75, Espoo",60.220298,24.692154
+"Maistraatinportti 4, Helsinki",60.198185,24.926011
+"Liusketie 16, Helsinki",60.237195,25.01659
+"Matinkartanontie 1, Espoo",60.15664,24.752658
+"Sepontie 1, Espoo",60.188206,24.790929
+"Myllynkivenkuja 4, Vantaa",60.284616,24.837486
+"Pasilan Puistotie 10, Helsinki",60.200027,24.923784
+"Fredrikinkatu 20, Helsinki",60.162696,24.938593
+"Aamuruskontie 2, Helsinki",60.283712,25.028118
+"Eteläinen Hesperiankatu 22, Helsinki",60.176423,24.923255
+"Helsingin medialukio, Helsinki",60.269825,25.030543
+"Ulvilantie 25, Helsinki",60.209483,24.87265
+"Bulevardi 6, Helsinki",60.165691,24.942317
+"Ukonkivenpolku 4, Vantaa",60.262,24.868066
+"Hertaksentie 2, Vantaa",60.290616,25.041832
+"Bulevardi 28, Helsinki",60.163679,24.935972
+"Kauriintie 4, Helsinki",60.272397,24.991042
+"Kielotie 21, Vantaa",60.298415,25.041474
+"Kuusisaari, Helsinki",60.185767,24.861868
+"Katajanokanlaituri 6, Helsinki",60.165302,24.963664
+"Korkeavuorenkatu 1, Helsinki",60.159586,24.947132
+"Aleksis Kiven Katu 38, Helsinki",60.189935,24.950558
+"Nuijamäki 6, Espoo",60.210895,24.764078
+"Teuvo Pakkalan Tie 2, Helsinki",60.227112,24.902929
+"Kumpulantie 1, Helsinki",60.19642,24.941259
+"Bemböle, Espoo",60.224645,24.680813
+"Pronssitie 4, Helsinki",60.231261,24.883609
+"Takomotie 8, Helsinki",60.21786,24.873533
+"Aapelinkatu, Espoo",60.155153,24.75022
+"Eteläranta 8, Helsinki",60.164675,24.952095
+"Myllymatkantie 4, Helsinki",60.224788,25.064394
+"Palokunnanmäki 1, Vantaa",60.299487,25.035003
+"Hevostilantie 1, Espoo",60.270343,24.7557
+"Albertinkatu 25, Helsinki",60.163818,24.934504
+"Jakomäentie, Helsinki",60.25535,25.069746
+"Siemenkuja 3, Helsinki",60.254994,25.011555
+"Hiihtäjäntie 1, Helsinki",60.194861,25.0284
+"Rastilantie 5, Helsinki",60.214278,25.131276
+"Väinölänkatu 17, Helsinki",60.213773,24.954594
+"Tiedekeskus Heureka, Vantaa",60.287679,25.04021
+"Kaivosvoudintie 4, Vantaa",60.265307,24.869261
+"Leinikkitie 11, Vantaa",60.310453,25.033168
+"Ilmalankatu 2, Helsinki",60.205584,24.916683
+"Kuusitie 4, Helsinki",60.19491,24.900546
+"Aleksis Kiven katu, Helsinki",60.195079,24.938804
+"Keskuskatu 2, Helsinki",60.168616,24.942134
+"Maininkipuisto, Espoo",60.151956,24.646389
+"Mankkaantie 2, Espoo",60.19413,24.768142
+"Kaitaan koulu ja lukio, Espoo",60.149483,24.696579
+"Kutojantie 4, Espoo",60.211286,24.750026
+"Keilaranta 10, Espoo",60.178655,24.834253
+"Myrskyläntie 22, Helsinki",60.224404,24.969586
+"Finnoontie 12, Espoo",60.169932,24.690605
+"Meriusva 5, Espoo",60.154713,24.636514
+"Urheilupuistontie 3, Espoo",60.177784,24.785949
+"Porvoonkatu 14, Helsinki",60.19064,24.945048
+"Piispanportti 12, Espoo",60.163912,24.735801
+"Elimäenkatu 5, Helsinki",60.193841,24.951613
+"Rosendalinkuja 3, Vantaa",60.267621,24.966999
+"Tilanhoitajankaari 8, Helsinki",60.231701,25.031208
+"Sörnäistenkatu 19, Helsinki",60.194329,24.973429
+"Salmisaarenranta 11, Helsinki",60.16623,24.899943
+"Karakalliontie 5, Espoo",60.227462,24.764286
+"Teuvo Pakkalan Tie 1, Helsinki",60.227585,24.90326
+"Junailijankuja 10, Helsinki",60.200452,24.936008
+"Kaarlenkatu 11, Helsinki",60.186015,24.952011
+"Piispankalliontie 17, Espoo",60.168863,24.750639
+"Liusketie 2, Helsinki",60.235564,25.013221
+"Pikku Satamakatu 2, Helsinki",60.165942,24.964381
+"Keilaranta 13, Espoo",60.178052,24.836384
+"Pitäjänmäentie 14, Helsinki",60.214903,24.875692
+"Puunhaltijankuja 1, Vantaa",60.323069,25.042696
+"Airport Hotel Pilotti;Ravintola Volare, Vantaa",60.284674,24.965799
+"Suutarila, Helsinki",60.283659,25.010861
+"Kanneltie 8, Helsinki",60.241196,24.878596
+"Viherlaaksonranta 7, Espoo",60.227757,24.730368
+"Haapaniemenkatu 5, Helsinki",60.181137,24.957907
+"Takkatie 1, Helsinki",60.221812,24.861234
+"Asentajankatu 6, Helsinki",60.198182,25.043374
+"Vanha Tapanilantie, Helsinki",60.261386,25.015923
+"Itämerenkatu 23, Helsinki",60.163454,24.906717
+"Castréninkatu 3, Helsinki",60.184066,24.94564
+"Viikinkaari 4, Helsinki",60.226327,25.014755
+"Bulevardi 7, Helsinki",60.164972,24.938235
+"Kiviaidankatu 2, Helsinki",60.153845,24.88313
+"Tiedekeskus Heureka, Vantaa",60.287679,25.04021
+"Lehtovuorenkatu 6, Helsinki",60.249,24.833529
+"Leinelänkaari 14, Vantaa",60.324567,25.038857
+"Kivipadontie 4, Helsinki",60.23191,24.948424
+"Laajavuorenkuja 3, Vantaa",60.281109,24.8411
+"Leppäsuonkatu 9, Helsinki",60.169429,24.922867
+"Koivuvaarankuja 2, Vantaa",60.256229,24.814253
+"Nauriskaski, Espoo",60.172957,24.652785
+"Mäkitorpantie 1, Helsinki",60.221632,24.948218
+"Käpylänaukio 1, Helsinki",60.213374,24.943932
+"Masalan asema, Kirkkonummi",60.158645,24.53919
+"Männikkötie 5, Helsinki",60.226045,24.929885
+"Nervanderinkatu 13, Helsinki",60.173932,24.928784
+"Mäkelänkatu 13, Helsinki",60.192352,24.961645
+"Savela, Helsinki",60.238316,24.986036
+"Petter Wetterin tie 1, Helsinki",60.192358,25.031349
+"Hämeentie 6, Helsinki",60.180892,24.951807
+"Töölönkatu 55, Helsinki",60.184897,24.918896
+"Rajatorpantie 41, Vantaa",60.255316,24.817152
+"Pirttikorpi 7, Espoo",60.171165,24.637243
+"Sörnäisten Rantatie 22, Helsinki",60.186951,24.970241
+"Ratatie 11, Vantaa",60.293002,25.044729
+"Helsinginkatu 21, Helsinki",60.18721,24.952658
+"Leinikkitie 9, Vantaa",60.310415,25.034238
+"Leppävaaran stadion, Espoo",60.225827,24.799135
+"Eerikinkatu 27, Helsinki",60.165373,24.929413
+"Kuntatalo, Helsinki",60.183931,24.940627
+"Harmotie 1, Vantaa",60.276696,25.100716
+"Itälahdenkatu 1, Helsinki",60.14758,24.882866
+"Korppaanmäentie 1, Helsinki",60.203959,24.89856
+"Kasarmikatu 21, Helsinki",60.165862,24.94811
+"Hämeentie, Helsinki",60.198494,24.961933
+"Kotisaarenkatu 3, Helsinki",60.202382,24.969648
+"Martinkeskus, Vantaa",60.276645,24.847481
+"Kaivosrinteentie 2, Vantaa",60.268428,24.870089
+"Itämerenkatu 12, Helsinki",60.1632,24.916249
+"Iho- ja Allergiasairaala, Helsinki",60.191633,24.894636
+"Niipperin koulu, Espoo",60.283328,24.747181
+"Kantelettarentie 8, Helsinki",60.240487,24.885435
+"Elimäenkatu 30, Helsinki",60.197463,24.947129
+"Nihtisillantie 1, Espoo",60.208113,24.754648
+"Miestentie 9, Espoo",60.178969,24.831491
+"Erik Palménin Aukio 1, Helsinki",60.203817,24.96079
+"Konalan puisto, Helsinki",60.232407,24.849004
+"Mankkaankallio 1, Espoo",60.196688,24.766416
+"Puolarmetsä, Espoo",60.175437,24.688335
+"Siltasaarenkatu 12, Helsinki",60.178733,24.949309
+"Kiviteltankatu 3, Helsinki",60.228791,24.996439
+"Seulastentie 11, Helsinki",60.275695,24.997694
+"Valimon asema, Helsinki",60.222071,24.875411
+"Veräjämäki, Helsinki",60.229646,24.981566
+"Helsinginkatu 28, Helsinki",60.186087,24.947966
+"Junailijankuja 5, Helsinki",60.199115,24.93786
+"Krakantie, Vantaa",60.289071,24.942487
+"Kappelitie 6, Espoo",60.167854,24.766374
+"Kärrynpyöräntie 1, Espoo",60.251608,24.72109
+"Kaniini, Helsinki",60.172612,24.947856
+"Ala-Tikkurila, 3354, Helsinki",60.286889,25.015055
+"Koskela, Helsinki",60.219706,24.964342
+"Koskelantie 39, Helsinki",60.215961,24.969567
+"Helsinginkatu 2, Helsinki",60.187461,24.961015
+"Kuunsäde, Espoo",60.174289,24.722665
+"Rajametsäntie 35, Helsinki",60.230131,24.934467
+"Leiviskätie 1, Helsinki",60.232428,24.881927
+"Pitäjänmäentie, Helsinki",60.223742,24.862514
+"Porthaninkatu 9, Helsinki",60.182585,24.952675
+"Nelikkotie 8, Espoo",60.162374,24.744072
+"Rahakamarinkatu 1, Helsinki",60.200936,24.920983
+"Pelimannintie 1, Helsinki",60.239123,24.886607
+"Roihuvuorentie 18, Helsinki",60.199815,25.055474
+"Albertinkatu 40, Helsinki",60.164927,24.930739
+"Risto Rytin Tie 33, Helsinki",60.189372,25.018034
+"Hämeentie 109, Helsinki",60.202248,24.966824
+"Takomotie 27, Helsinki",60.21809,24.870503
+"Lumikintie 4, Helsinki",60.202881,25.056934
+"Agronominkatu 26, Helsinki",60.231304,25.037733
+"Asemanaukio, Kerava",60.404494,25.105351
+"Servin Maijan Tie 10, Espoo",60.191482,24.836528
+"Iivisniementie 1, Espoo",60.149447,24.696529
+"Sundsberg, Kirkkonummi",60.153067,24.548403
+"Alhokuja 8, Helsinki",60.263737,24.9868
+"Kirkkotallintie 1, Kirkkonummi",60.123818,24.438418
+"Pakilantie 8, Helsinki",60.230449,24.935873
+"Puolarinportti 1, Espoo",60.176081,24.703823
+"Mäkelänkatu, Helsinki",60.191577,24.961917
+"Suonotkontie 1, Helsinki",60.232251,24.936212
+"Kaivokatu 10, Helsinki",60.169551,24.940994
+"Helsingin rautatieasema, Helsinki",60.171831,24.9412
+"Intiankatu 1, Helsinki",60.20654,24.972567
+"Kauppakartanonkatu 16, Helsinki",60.207401,25.082383
+"Esterinportti 2, Helsinki",60.19695,24.928001
+"Kalevankatu 1, Helsinki",60.168401,24.939858
+"Lummetie 1, Vantaa",60.296159,25.044396
+"Maunulan Yhteiskoulu ja Helsingin matematiikkalukio, Helsinki",60.230034,24.924964
+"Pietari Hannikaisen Tie 6, Helsinki",60.226734,24.897752
+"Mannerheimintie 79, Helsinki",60.193012,24.909488
+"Ramsaynkuja 1, Espoo",60.195333,24.589081
+"Lammastie, Vantaa",60.260166,24.805211
+"Sturenkatu 37, Helsinki",60.195522,24.959449
+"Mäkelänkatu 50, Helsinki",60.196323,24.951837
+"Otaranta 2, Espoo",60.183834,24.836668
+"Henrik Lättiläisen Katu 3, Helsinki",60.225084,24.987077
+"Haapaniemenrinne 1, Espoo",60.251571,24.724129
+"Ratapihantie 1, Helsinki",60.197796,24.93733
+"Mikkolantie 1, Helsinki",60.234234,24.975155
+"Vanha Viertotie 21, Helsinki",60.211066,24.88455
+"Fleminginkatu 25, Helsinki",60.189259,24.953305
+"Fleminginkatu 23, Helsinki",60.188721,24.953339
+"Alakaupunki, E4034, Espoo",60.155289,24.631323
+"Kala-Matti 1, Espoo",60.157937,24.737293
+"Venäläinen koulu, 1948, Helsinki",60.237889,24.897051
+"Kirkkokatu 6, Helsinki",60.170835,24.957805
+"Rörstrandinkatu, Helsinki",60.206102,24.978063
+"Kivelän sairaala, Helsinki",60.180682,24.918235
+"Köydenpunojankatu 8, Helsinki",60.163579,24.923272
+"Rinnekoti, Espoo",60.35292,24.654663
+"Mannerheimintie 3, Helsinki",60.169551,24.940994
+"Takojankuja 3, Kerava",60.403119,25.140318
+"Kirstintie 30, Espoo",60.205473,24.672928
+"Mannerheimintie 14, Helsinki",60.168401,24.939858
+"Kylänvanhimmantie 29, Helsinki",60.228437,24.96372
+"Porintie 1, Helsinki",60.203991,24.871273
+"Katajaharju, Helsinki",60.168296,24.857289
+"Pursimiehenkatu, Helsinki",60.159616,24.938459
+"Lautatarhankatu 6, Helsinki",60.189304,24.970835
+"Porttikuja 1, Espoo",60.199451,24.768321
+"Kangasalantie 13, Helsinki",60.197767,24.955752
+"Trillakatu 1, Espoo",60.217276,24.786229
+"Kämnerintie 4, Helsinki",60.277457,25.027843
+"Vilhonvuorenkatu 1, Helsinki",60.187593,24.963528
+"Suezinkatu 3, Helsinki",60.158603,24.920379
+"Purotie 8, Helsinki",60.215018,24.867688
+"Takomotie 23, Helsinki",60.218489,24.872987
+"Kauppamiehentie 1, Espoo",60.176593,24.801788
+"Väinölänkatu 2, Helsinki",60.210695,24.94549
+"Hki linja-autoasema, Helsinki",60.169621,24.932544
+"Isonniitynkatu 3, Helsinki",60.202181,24.948441
+"Kontukuja 5, Helsinki",60.243806,25.085693
+"Helsinginkatu 15, Helsinki",60.187355,24.955047
+"Koivumäentie 16, Vantaa",60.263995,25.102119
+"Dagmarinkatu 3, Helsinki",60.173928,24.929686
+"Kaitaan koulu, Espoo",60.149296,24.695278
+"Liusketie 3, Helsinki",60.234503,25.013122
+"Kiillekuja 3, Helsinki",60.233108,25.005134
+"Sörnäisten Rantatie 6, Helsinki",60.179463,24.954096
+"Kanavaranta 7, Helsinki",60.168973,24.959994
+"Töölöntullinkatu 1, Helsinki",60.189627,24.915259
+"1 Lapinlahdenkatu, Helsinki",60.166513,24.93165
+"Viikintie 1, Helsinki",60.216375,24.981997
+"Siltakuja 1, Sipoo",60.366397,25.260643
+"Ryytimaa 1, Espoo",60.239967,24.71012
+"Tuusulantaival 42, Kerava",60.408623,25.08317
+"Pyhtäänkorvenkuja 6, Vantaa",60.300852,24.970437
+"Albertinkatu 1, Helsinki",60.159703,24.940799
+"Pohjoinen Hesperiankatu 1, Helsinki",60.178003,24.928889
+"Dagmarinkatu 5, Helsinki",60.173555,24.929385
+"Castréninkatu 18, Helsinki",60.185601,24.947347
+"Hiomotie 42, Helsinki",60.218944,24.869978
+"Helsingintie 10, Kauniainen",60.213169,24.7356
+"Aleksis Kiven Katu 3, Helsinki",60.189727,24.957461
+"Kaupintie 14, Helsinki",60.230126,24.882328
+"Itämerenkatu 3, Helsinki",60.163956,24.91977
+"Perkkaantie 3, Espoo",60.216763,24.821467
+"Koisotie 4, Vantaa",60.301184,25.016188
+"Itäportti 1, Espoo",60.175491,24.73742
+"Kaarlenkatu 1, Helsinki",60.184468,24.951908
+"Poutamäentie 13, Helsinki",60.219315,24.852333
+"Maininkitie 9, Espoo",60.151864,24.64753
+"Savelantie 3, Helsinki",60.24034,24.993349
+"Siilitie 7, Helsinki",60.210092,25.040372
+"Brahenkatu, Helsinki",60.189768,24.94839
+"Maapadontie 1, Helsinki",60.231585,24.94942
+"Sturenkatu 25, Helsinki",60.193471,24.955605
+"Erkki Melartinin Tie 1, Helsinki",60.246488,24.989467
+"Aleksanterinkatu 9, Helsinki",60.169168,24.948192
+"Eteläranta 1, Helsinki",60.163776,24.952468
+"Tyynenmerenkatu 3, Helsinki",60.158922,24.921242
+"Sorolantien leikkialue, Helsinki",60.25369,24.876406
+"Vanha Turuntie 14, Kauniainen",60.221526,24.717943
+"Maistraatinkatu 1, Helsinki",60.197973,24.923949
+"Mätästie 1, Helsinki",60.262997,25.079348
+"Unioninkatu 37, Helsinki",60.173556,24.950785
+"Varikkotie, Helsinki",60.208882,25.062809
+"Ratamestarinkatu 11, Helsinki",60.201224,24.93946
+"Porthaninkatu 15, Helsinki",60.183834,24.955068
+"Katajalaakso 1, Espoo",60.167526,24.625624
+"Keilalahdentie 4, Espoo",60.170162,24.828502
+"Matinkatu 22, Espoo",60.157759,24.740027
+"Kaasutehtaankatu 1, Helsinki",60.186696,24.974134
+"Kaadekuja 1, Helsinki",60.253901,25.074531
+"Kivikonkaari 14, Helsinki",60.238829,25.06763
+"Minnesstensstigen 1, Helsingfors",60.236575,25.021324
+"Kivihaantie 1, Helsinki",60.209682,24.904312
+"Laajalahdentie 23, Helsinki",60.201696,24.878242
+"Simonkatu 9, Helsinki",60.169125,24.935
+"Hankasuontie 11, Helsinki",60.249193,24.840321
+"Melkonkatu 1, Helsinki",60.147554,24.885137
+"Mannerheimintie 91, Helsinki",60.19466,24.904621
+"Myllypurontie, Helsinki",60.224873,25.059304
+"Leppävaaran stadion, Espoo",60.225827,24.799135
+"Runeberginkatu 43, Helsinki",60.175938,24.922672
+"Liisankatu 16, Helsinki",60.173908,24.954387
+"Viljo Sohkasen Katu 3, Vantaa",60.29784,25.051244
+"Olympiaranta 1, Helsinki",60.160764,24.958862
+"Otaniementie 9, Espoo",60.184755,24.827755
+"Anjankuja 3, Espoo",60.157255,24.739936
+"Viherkalliontie 7, Espoo",60.228399,24.747444
+"Tammasaarenkatu 1, Helsinki",60.161071,24.903751
+"Piilipuuntie 31, Espoo",60.189427,24.738661
+"Myllypurontie 22, Helsinki",60.223903,25.061594
+"Rajamänty, E1501, Espoo",60.22565,24.74736
+"Haaga, Helsinki",60.222458,24.905532
+"Hakaniemenranta 6, Helsinki",60.178422,24.955331
+"Unikkotie 5, Vantaa",60.292541,25.039039
+"Hansatie 4, Espoo",60.186795,24.589834
+"Hämeentie 85, Helsinki",60.196424,24.963071
+"Kivalterintie 20, Helsinki",60.229949,24.952285
+"Mikonkatu 8, Helsinki",60.169598,24.944632
+"Maasälväntie 5, Nurmijärvi",60.362158,24.728589
+"Kauniala, Kauniainen",60.218542,24.701444
+"Karhunkierros 4, Vantaa",60.260385,24.810759
+"Leppälinnunrinne 6, Espoo",60.230128,24.781858
+"Mannerheimintie 40, Helsinki",60.177142,24.929538
+"Otaniementie, Espoo",60.18015,24.834483
+"Friisilä, Espoo",60.166243,24.719322
+"Vaakatie 6, Helsinki",60.230205,24.875984
+"Antti Korpin Tie 1, Helsinki",60.218009,24.96666
+"Museokatu 1, Helsinki",60.174939,24.931732
+"Lintulahdenkuja 4, Helsinki",60.183229,24.961273
+"Tuulikuja 2, Espoo",60.170598,24.801576
+"Ratakatu, Helsinki",60.162826,24.943309
+"Pyyntitie 1, Espoo",60.158267,24.734496
+"Nauvontie 18, Helsinki",60.207601,24.900529
+"Mechelininkatu, Helsinki",60.173492,24.919133
+"Tunnelitie, Kauniainen",60.212053,24.728824
+"Malminkatu 3, Helsinki",60.168204,24.926658
+"Docksgatan, Helsingfors",60.158471,24.934135
+"Pasilanraitio 10, Helsinki",60.200564,24.924183
+"Työpajankatu 13, Helsinki",60.188174,24.973899
+"Hämeentie 32, Helsinki",60.183863,24.958691
+"Energiakuja 3, Helsinki",60.166671,24.902258
+"Joupinpuisto 1, Espoo",60.201966,24.680918
+"Kuuluttajankatu 2, Helsinki",60.204807,24.91814
+"Helsinginkatu 13, Helsinki",60.18751,24.955759
+"Lumikintie 3, Helsinki",60.203789,25.058198
+"Katajanokan terminaali, Helsinki",60.16426,24.969331
+"Niittyportti 4, Espoo",60.169612,24.769986
+"Televisiokatu 4, Helsinki",60.204326,24.924703
+"Vellamonkatu 1, Helsinki",60.193102,24.966072
+"Seltterikuja 4, Helsinki",60.238024,24.848435
+"Ukonvaaja 1, Espoo",60.18546,24.792159
+"Elimäenkatu 1, Helsinki",60.193487,24.953132
+"Pohjoinen Hesperiankatu 15, Helsinki",60.177692,24.924509
+"Miestentie 1, Espoo",60.178232,24.828168
+"Pasilan asema, Helsinki",60.199228,24.933114
+"Pääskylänrinne 3, Helsinki",60.187927,24.965924
+"Talin keilahalli, Helsinki",60.210315,24.878877
+"Laajasuontie 31, Helsinki",60.21988,24.897144
+"Haukilahdensolmu, Espoo",60.167484,24.772868
+"Mannerheimintie, Helsinki",60.187696,24.918749
+"Puistomäki 1, Espoo",60.216715,24.788144
+"Radiokatu 11, Helsinki",60.202923,24.920569
+"Kokkokalliontie 3, Helsinki",60.228824,24.851585
+"Otto Brandtin Tie 16, Helsinki",60.233136,24.978492
+"Sähkötie 5, Vantaa",60.277384,24.975273
+"Ruoholahdenkatu 21, Helsinki",60.164586,24.923876
+"Adolf Lindforsin tie, Helsinki",60.229132,24.893596
+"Fredrikinkatu 12, Helsinki",60.160908,24.941445
+"Untamontie 1, Helsinki",60.209937,24.948191
+"Harustie 7, Helsinki",60.203507,25.121586
+"Neljäs Linja 2, Helsinki",60.181669,24.953832
+"Atomitie 5, Helsinki",60.222465,24.872242
+"Hiekkaharjun asema, Vantaa",60.303175,25.049125
+"Kielotie 13, Vantaa",60.294127,25.03936
+"Koskelantie 5, Helsinki",60.207976,24.946851
+"Untamontie 9, Helsinki",60.211184,24.951542
+"Kipparlahden silmukka, Helsinki",60.192017,25.019554
+"Otakallio 1, Espoo",60.183139,24.83439
+"Kuunkatu, Espoo",60.172322,24.722822
+"Käpyläntie 2, Helsinki",60.21407,24.95759
+"Teollisuuskatu 18, Helsinki",60.194507,24.94477
+"Sumatrantie 1, Helsinki",60.20738,24.969357
+"Antaksentie 4, Vantaa",60.294249,24.945584
+"Sulkapolku 6, Helsinki",60.225497,24.857473
+"Arkadiankatu 28, Helsinki",60.171329,24.920854
+"Svanströminkuja 1, Helsinki",60.167507,25.043793
+"Laaksotie 20, Vantaa",60.321167,25.010719
+"Emännänkuja 1, Vantaa",60.283042,24.871255
+"Eiran aikuislukio, Helsinki",60.155683,24.942685
+"Keilasatama 5, Espoo",60.1728,24.829951
+"Kylmäojantie, Vantaa",60.32075,25.01585
+"Kanneltie 2, Helsinki",60.240597,24.883874
+"Laajasuontie 35, Helsinki",60.220257,24.894321
+"Katajanokanlaituri 8, Helsinki",60.163838,24.96835
+"Katajanokan terminaali, Helsinki",60.16426,24.969331
+"Unioninkatu 45, Helsinki",60.175374,24.951051
+"Lapinlahdenkatu 16, Helsinki",60.167202,24.922881
+"Kyllikinportti 2, Helsinki",60.199845,24.926483
+"Karpalokuja 7, Helsinki",60.23141,25.071932
+"Porslahdentie 24, Helsinki",60.213291,25.149238
+"Lönnrotinkatu 1, Helsinki",60.167549,24.941083
+"Snellmaninkatu, Helsinki",60.173956,24.95235
+"Kyllikinportti, Helsinki",60.199837,24.925613
+"Vanha Talvitie 19, Helsinki",60.191963,24.97794
+"Hietapellontie 11, Helsinki",60.258708,25.013119
+"Viikin biokeskus, 3175, Helsinki",60.225321,25.016734
+"Vilppulantie 26, Helsinki",60.250658,25.02136
+"Turunlinnantie 1, Helsinki",60.212184,25.080227
+"Klariksentie 1, Espoo",60.18436,24.740236
+"Käskynhaltijantie 5, Helsinki",60.23704,24.972453
+"Eliel Saarisen Tie 15, Helsinki",60.224041,24.896697
+"Maistraatinportti 2, Helsinki",60.198339,24.927228
+"Heiniitty 5, Espoo",60.236994,24.723189
+"Kasarmikatu 4, Helsinki",60.160015,24.947574
+"Lehtikallio 4, Vantaa",60.2551,24.812774
+"Mannerheimintie 6, Helsinki",60.167024,24.941999
+"Nuijamiestentie 7, Helsinki",60.225933,24.9062
+"Pakkalan puistotie, Vantaa",60.289882,24.949182
+"Opastinsilta 9, Helsinki",60.199695,24.937572
+"Riistavuorenkuja 4, Helsinki",60.218077,24.885452
+"Tynnyrintekijänkatu 1, Helsinki",60.18888,24.971312
+"Herttoniemen sairaala, Helsinki",60.207444,25.036071
+"Leppälinnunrinne, Espoo",60.229247,24.782926
+"Sturenkatu 22, Helsinki",60.193849,24.954463
+"Metsäläntie 2, Helsinki",60.219909,24.929784
+"Lahtisvägen 666, Sibbo",60.329909,25.115141
+"Fleminginkatu 13, Helsinki",60.186174,24.953624
+"Etelä-Tapiolan koulu ja lukio, Espoo",60.178277,24.793653
+"Myllynkivenkuja 6, Vantaa",60.285461,24.841112
+"Hirsipadontie 7, Helsinki",60.23416,24.950433
+"Henrikintie 5, Helsinki",60.226352,24.850916
+"Talvelantie 6, Helsinki",60.253541,24.999174
+"Suvilahdenkatu 9, Helsinki",60.188246,24.96805
+"Pyynikintie 1, Helsinki",60.232707,24.999415
+"Kaisaniemi Park, Helsinki",60.174831,24.946462
+"Porkkalankatu 24, Helsinki",60.163806,24.906875
+"Keinulaudantie 7, Helsinki",60.235723,25.072672
+"Neilikkatie 17, Vantaa",60.291209,25.032171
+"Sturenkatu 7, Helsinki",60.187701,24.944889
+"Hämeentie, Helsinki",60.198494,24.961933
+"Pohjolankatu 2, Helsinki",60.214402,24.944175
+"Bulevardi 32, Helsinki",60.163209,24.934614
+"Eduskuntatalo, Helsinki",60.172515,24.933202
+"Annankatu 29, Helsinki",60.168017,24.935953
+"Servin mökki, Espoo",60.188418,24.836532
+"Hyrylä, Tuusula",60.399494,25.017824
+"Mannerheimintie 20, Helsinki",60.169543,24.938182
+"Maistraatinkatu 7, Helsinki",60.200133,24.921936
+"Kätilöopisto, 3055, Helsinki",60.204019,24.950394
+"Mustialankatu 3, Helsinki",60.228329,25.021316
+"Terhotie 1, Vantaa",60.256657,24.800994
+"Kaunispääntie, Helsinki",60.232527,25.128362
+"Tehtaankatu, Helsinki",60.158196,24.94469
+"Vuorenpeikontie 1, Helsinki",60.201467,25.059111
+"Valimotie 13, Helsinki",60.217925,24.879294
+"Unioninkatu 1, Helsinki",60.163309,24.952072
+"Turkismiehentie 8, Helsinki",60.225867,24.858712
+"Tilkuntie 5, Vantaa",60.280513,24.957878
+"Eteläesplanadi 1, Helsinki",60.167413,24.950285
+"Hämeentie 155, Helsinki",60.212229,24.979256
+"Laajalahdentie 30, Helsinki",60.201586,24.876463
+"Hagelstamintie 32, Vantaa",60.283731,24.969146
+"Fazerila, Vantaa",60.256388,25.104686
+"Alppikatu 3, Helsinki",60.184724,24.94118
+"Pohjolankatu 1, Helsinki",60.213374,24.943932
+"Matinkylän jäähalli 2, Espoo",60.15988,24.751167
+"Takaniityntie 5, Helsinki",60.256842,24.997128
+"Sanomala, Vantaa",60.287494,24.851606
+"Leppäsuonkatu 7, Helsinki",60.169344,24.923702
+"Servin Maijan Tie 6, Espoo",60.190577,24.836083
+"Sähkötie 3, Vantaa",60.276262,24.97527
+"Paraistentie 17, Helsinki",60.20362,24.904338
+"Upseerinkatu 1, Espoo",60.216451,24.819394
+"Kylänvanhimmantie 25, Helsinki",60.227821,24.964553
+"Sepetlahdentie 1, Espoo",60.153775,24.746067
+"Atomitie 2, Helsinki",60.223614,24.866176
+"Kuitinmäki, Espoo",60.171923,24.726202
+"Antaksentie 1, Vantaa",60.292477,24.944502
+"Eerikinkatu 11, Helsinki",60.167059,24.933832
+"Katajanokanranta 21, Helsinki",60.168582,24.975466
+"Itämerenkatu 5, Helsinki",60.164158,24.918946
+"Ristipellontie 1, Helsinki",60.235905,24.856811
+"Jännetie 1, Helsinki",60.227005,24.855225
+"Mannerheimintie, Helsinki",60.187696,24.918749
+"Tietotie 3, Espoo",60.184759,24.816687
+"Näyttelijäntie 1, Helsinki",60.226073,24.895176
+"Lääkärinkatu 2, Helsinki",60.191239,24.913804
+"Otakaari 3, Espoo",60.188162,24.829924
+"Vähäntuvantie, Helsinki",60.233091,24.851574
+"Runeberginkatu, Helsinki",60.169779,24.926741
+"Radiokatu 22, Helsinki",60.20421,24.916698
+"Kääpiöidenpolku 4, Helsinki",60.202575,25.063015
+"Sturenkatu, Helsinki",60.190757,24.948473
+"Sisarustentie 2, Helsinki",60.25385,24.89773
+"Välskärinkatu 12, Helsinki",60.179966,24.919442
+"Narinkka 1, Helsinki",60.169815,24.934132
+"Juvanmalmi, Espoo",60.277358,24.762009
+"Pieni Roobertinkatu, Helsinki",60.164196,24.946062
+"Siltamäen ostosk., 3282, Helsinki",60.275032,24.991028
+"Vattuniemenkatu 18, Helsinki",60.152887,24.883299
+"Kalteentie 1, Helsinki",60.265067,25.085825
+"Haahkatie 15, Helsinki",60.156937,24.876534
+"Kivalterintie 21, Helsinki",60.229791,24.953668
+"Sähkötie 1, Vantaa",60.276789,24.97276
+"Auroranmäki 1, Espoo",60.239708,24.702929
+"Käenkuja 8, Helsinki",60.185928,24.966246
+"Taivalmäki 1, Espoo",60.169166,24.774433
+"Seurasaari, Helsinki",60.181125,24.884139
+"Hämeentie 38, Helsinki",60.184798,24.959913
+"Elimäenkatu 2, Helsinki",60.1929,24.952275
+"Ajomiehentie 1, Helsinki",60.239048,24.848404
+"Ulvilantie 23, Helsinki",60.209807,24.870445
+"Runeberginkatu 40, Helsinki",60.178125,24.922336
+"Tilanhoitajankaari 1, Helsinki",60.233346,25.03008
+"Kirstinkatu 15, Helsinki",60.188782,24.946824
+"Mikonkatu 7, Helsinki",60.169573,24.945914
+"Kalkkipellontie 4, Espoo",60.219411,24.832846
+"Jämsänkatu 2, Helsinki",60.196478,24.943258
+"Hevosmiehenkatu 13, Helsinki",60.254946,25.066102
+"Kirkonkyläntie 23, Helsinki",60.254525,25.003053
+"Kielotie, Vantaa",60.289791,25.035724
+"Mätästie 5, Helsinki",60.266848,25.084166
+"Haahkakuja 5, Helsinki",60.15716,24.875834
+"Sopulirinne 2, Helsinki",60.21548,25.043354
+"Mantelikuja 1, Vantaa",60.256177,24.805093
+"Helsinki-Vantaa lentoasema T1, Vantaa",60.31542,24.970949
+"Santakatu 2, Helsinki",60.162599,24.920306
+"Antaksentie 21, Vantaa",60.29376,24.950809
+"Salpausseläntie 13, Helsinki",60.231125,24.999349
+"Kirjanpitäjänkuja 4, Espoo",60.206728,24.667677
+"Asemamiehenkatu 4, Helsinki",60.200566,24.93869
+"Kirstinmäki 1, Espoo",60.201701,24.666843
+"Strömbergintie 8, Helsinki",60.220221,24.863378
+"Valimotie 11, Vantaa",60.275102,24.973461
+"Latokartanonkaari 9, Helsinki",60.229015,25.019107
+"Kaupintie 1, Helsinki",60.233978,24.889539
+"Aleksis Kiven Katu 56, Helsinki",60.192254,24.944821
+"Robert Huberin Tie 4, Vantaa",60.296359,24.961504
+"Moisiontie, Helsinki",60.269905,25.02955
+"Otsolahdentie 5, Espoo",60.176658,24.819328
+"Kaupintie 4, Helsinki",60.232286,24.887625
+"Tarhurintie 2, Vantaa",60.313913,25.04299
+"Vallinojantie, Vantaa",60.358603,25.086015
+"Elimäenkatu 17, Helsinki",60.195109,24.948233
+"Rekolan asema, Vantaa",60.332723,25.068449
+"Kutomotie 2, Helsinki",60.214915,24.875668
+"Petas, E1524, Espoo",60.224188,24.705562
+"Heikinlaakso, Helsinki",60.268723,25.073787
+"Nordenskiöldinkatu 12, Helsinki",60.18756,24.91687
+"Jönsaksentie 4, Vantaa",60.260597,24.856227
+"Valimotie 7, Vantaa",60.271796,24.972219
+"Kaarelantie 86, Helsinki",60.243713,24.888334
+"Hirsipadontie 1, Helsinki",60.235021,24.955581
+"Keskuskatu 2, Helsinki",60.168616,24.942134
+"Porkkalankatu 5, Helsinki",60.164768,24.909175
+"Nihtitorpankuja 3, Espoo",60.208746,24.755994
+"Käräjäkuja 1, Vantaa",60.286854,24.94737
+"Suvilahdenkatu 1, Helsinki",60.187115,24.966876
+"Kampinkuja 2, Helsinki",60.168131,24.93061
+"Nöykkiön koulu, Espoo",60.168169,24.663506
+"Keikarinkuja 1, Vantaa",60.287847,24.958778
+"Siltavoudintie 14, Helsinki",60.232039,24.966748
+"Helsinki",60.17132,24.941457
+"Annankatu 1, Helsinki",60.162905,24.94278
+"Tuulimyllyntie 1, Helsinki",60.227401,25.066191
+"Visamäki, Espoo",60.187176,24.784017
+"Porthaninkatu 1, Helsinki",60.181109,24.95017
+"Kalevankatu 3, Helsinki",60.168168,24.939314
+"Näyttelijäntie 18, Helsinki",60.231799,24.895459
+"Itäinen Puistotie 14, Helsinki",60.156678,24.961242
+"Paciuksenkatu 27, Helsinki",60.195328,24.891806
+"Siltasaarenkatu 18, Helsinki",60.180502,24.94927
+"Uudenmaankatu, Helsinki",60.163895,24.939131
+"Karakallion koulu, Espoo",60.229681,24.757276
+"Kamreerintie 3, Espoo",60.204238,24.6569
+"Aleksanterinkatu 52, Helsinki",60.168616,24.942134
+"Samariantie, Espoo",60.200392,24.652282
+"Arabiankatu 1, Helsinki",60.206267,24.974118
+"Siltavuorenpenger 3, Helsinki",60.175406,24.953699
+"Valimotie 19, Vantaa",60.281061,24.974901
+"Iso Roobertinkatu 1, Helsinki",60.164203,24.943672
+"Eerikinkatu 1, Helsinki",60.168017,24.937088
+"Kaitaa, Espoo",60.144732,24.691708
+"Rekipellontie 15, Helsinki",60.238937,25.09248
+"Lehtikuusentie 4, Helsinki",60.196443,24.906023
+"Kivistö, Vantaa",60.314247,24.846541
+"Vilhonvuorenkatu 11, Helsinki",60.186422,24.96681
+"Puotilan metroasema, Helsinki",60.214615,25.093921
+"Tilanhoitajankaari 12, Helsinki",60.230348,25.03026
+"Kipparinkuja 1, Espoo",60.150077,24.648594
+"Koivukyläntie 47, Vantaa",60.31483,25.035765
+"Venevalkamantie 9, Kauniainen",60.223828,24.713413
+"Ruoholahdenkatu 23, Helsinki",60.164304,24.923064
+"Kylävainionkuja 6, Espoo",60.209905,24.67265
+"Paloheinä, Helsinki",60.252313,24.932633
+"Teknobulevardi 3, Vantaa",60.305965,24.966517
+"Hämeentie, Helsinki",60.204961,24.970651
+"Saanatunturintie 1, Helsinki",60.236104,25.124976
+"Louhelan asema, Vantaa",60.270557,24.853503
+"Porvoonkatu 27, Helsinki",60.191691,24.943882
+"Hämeentie 111, Helsinki",60.20226,24.967599
+"Martinkyläntie, Vantaa",60.284063,24.844623
+"Viikinranta, 3071, Helsinki",60.218909,24.986951
+"Elimäenkatu 25, Helsinki",60.196715,24.94815
+"Kuusikkotie 3, Helsinki",60.229963,24.925411
+"Mannerheimintie 30, Helsinki",60.172624,24.932977
+"Kilonkartanontie 1, Espoo",60.223119,24.785419
+"Leppävaaran lukio, Espoo",60.225844,24.806059
+"Itätuulenkuja 8, Espoo",60.174527,24.804505
+"Luoma, Kirkkonummi",60.172376,24.549913
+"Riihenkulma, Helsinki",60.242996,25.012783
+"Lokkalantie 1, Helsinki",60.200017,24.884504
+"Hakaniemi, Helsinki",60.179002,24.95128
+"Mannerheimintie 107, Helsinki",60.204788,24.89986
+"Stenbäckinkatu 1, Helsinki",60.189775,24.915539
+"Roomankatu 5, Helsinki",60.201296,24.96856
+"Soukanahde, Espoo",60.14012,24.673919
+"Ajomiehentie 14, Helsinki",60.238354,24.848269
+"Viherlaaksonranta 10, Espoo",60.229659,24.732855
+"Yliopistonkatu 1, Helsinki",60.17033,24.949562
+"Hitsaajankatu 1, Helsinki",60.19177,25.025285
+"Kaupintie 16, Helsinki",60.229671,24.881364
+"Aku Korhosen Tie 2, Helsinki",60.233948,24.89216
+"Kielotie 11, Vantaa",60.292728,25.038322
+"Viittakorpi 1, Espoo",60.16557,24.681574
+"Tekniikantie 4, Espoo",60.181238,24.821423
+"Käpyläntie 12, Helsinki",60.21732,24.958055
+"Krogiuksentie 17, Helsinki",60.184578,24.858859
+"Lauttasaaren Yhteiskoulu, Helsinki",60.158468,24.863103
+"Neitsytpolku 1, Helsinki",60.156342,24.95047
+"Malmin lentoasema, 3399, Helsinki",60.245288,25.04532
+"Kannelmäki, Helsinki",60.239722,24.876612
+"Niittymaanaukea, Espoo",60.171582,24.782021
+"Hietalahdentori, Helsinki",60.162216,24.929517
+"Rälssitie 13, Vantaa",60.299523,24.974012
+"Jakomäen ostosk., 3500, Helsinki",60.261675,25.075226
+"Hakarinne 2, Espoo",60.17322,24.797164
+"Siilitie 9, Helsinki",60.210712,25.039776
+"K-citymarket Helsinki Ruoholahti, Helsinki",60.163609,24.910931
+"Pengerkatu 1, Helsinki",60.182697,24.955301
+"Otaranta 8, Espoo",60.186529,24.835736
+"Marsinkuja 1, Vantaa",60.341458,25.098003
+"Oltermannintie 32, Helsinki",60.228651,24.94675
+"Kaarelankuja 2, Helsinki",60.2385,24.899997
+"Illenpiha 4, Vantaa",60.282975,24.960836
+"Suursuonlaita 1, Helsinki",60.234707,24.935877
+"Porvoonkatu 15, Helsinki",60.190162,24.947207
+"Kilpolantie 16, Helsinki",60.239717,25.087413
+"Tilkankatu 2, Helsinki",60.203497,24.895486
+"Topeliuksenkatu 1, Helsinki",60.179583,24.923109
+"Rapakivenkuja 1, Helsinki",60.239572,25.003783
+"Mäkitorpantie 3, Helsinki",60.222902,24.949161
+"Tilanhoitajankaari 3, Helsinki",60.232523,25.02975
+"Sturenkatu 16, Helsinki",60.193118,24.951369
+"Lippajärvi, Espoo",60.230526,24.716236
+"Radiokatu 1, Helsinki",60.203107,24.927703
+"Trillakatu 5, Espoo",60.218129,24.786225
+"Salomonkatu 17, Helsinki",60.169019,24.929382
+"Piispanpiha 4, Espoo",60.164077,24.733861
+"Lehtikuusentie 1, Helsinki",60.19466,24.904551
+"Ratavartijankatu 5, Helsinki",60.196712,24.936387
+"Näyttelijäntie 15, Helsinki",60.230794,24.892074
+"Kerttulinkuja 1, Helsinki",60.189105,25.037547
+"Kyläsaarenkatu 8, Helsinki",60.19948,24.971415
+"Kallion kirkko, Helsinki",60.184276,24.949341
+"Palkkatilanportti 1, Helsinki",60.196325,24.928257
+"Helsingin tuomiokirko, Helsinki",60.170374,24.952194
+"Kulovalkeantie 21, Espoo",60.207568,24.685883
+"Pyöräilystadion, Helsinki",60.20309,24.945357
+"Meritullinkatu 1, Helsinki",60.17034,24.958935
+"Suvilahti, Helsinki",60.186582,24.972701
+"Hämeentie 156, Helsinki",60.213696,24.978062
+"Vihdintie 1, Helsinki",60.209545,24.88999
+"Upseerinkatu 11, Espoo",60.214822,24.820278
+"Mäkelänkatu, Helsinki",60.191577,24.961917
+"Kivalterintie, Helsinki",60.228451,24.950423
+"Kaisaniemi, Helsinki",60.174969,24.950534
+"Kumpulantie 9, Helsinki",60.196435,24.945155
+"Hämeentie 9, Helsinki",60.18184,24.956184
+"Kotkatie 6, Espoo",60.230394,24.761847
+"Töölöntulli 2, Helsinki",60.19076,24.913023
+"Kipparinkatu 2, Espoo",60.150566,24.64928
+"Messeniuksenkatu, Helsinki",60.187975,24.915445
+"Lipparinne 1, Espoo",60.238834,24.735184
+"Mechelininkatu, Helsinki",60.173492,24.919133
+"Neljäs Linja 1, Helsinki",60.181882,24.954883
+"Ruotsinpiha 1, Vantaa",60.28554,24.958867
+"Tilkankatu 39, Helsinki",60.197952,24.898692
+"Olarin koulu ja lukio, Espoo",60.180365,24.737449
+"Hämeentie, Helsinki",60.198494,24.961933
+"Pasilan Puistotie 6, Helsinki",60.197585,24.924948
+"Tammistonkatu 23, Vantaa",60.272613,24.963977
+"Kasavuorentie 1, Kauniainen",60.215411,24.703004
+"Raumantie 4, Helsinki",60.207682,24.870655
+"Mannerheiminaukio 1, Helsinki",60.171171,24.938927
+"Aurorakoti, Espoo",60.236922,24.706917
+"Arkadiankatu 22, Helsinki",60.170781,24.924278
+"Merikasarminkatu 1, Helsinki",60.166591,24.969186
+"Myrttitie 2, Helsinki",60.244307,24.996105
+"Kuunkehrä 2, Espoo",60.173007,24.725024
+"Lotankatu 1, Espoo",60.235312,24.831886
+"Eläintarhantie 5, Helsinki",60.181851,24.942424
+"Martinkyläntie 48, Vantaa",60.276324,24.820586
+"Ukkostie 1, Helsinki",60.247579,24.996339
+"Hämeentie 11, Helsinki",60.183027,24.95923
+"Kulorastaantie 3, Vantaa",60.34649,25.058437
+"Sörnäisten Rantatie 27, Helsinki",60.186422,24.96681
+"Kilonpuiston koulu, Espoo",60.216103,24.791216
+"Leppäkorpi, Vantaa",60.362605,25.095628
+"Yrjönkatu 24, Helsinki",60.167439,24.939179
+"Merimiehenkatu 36, Helsinki",60.15916,24.933229
+"Louhikkotie 20, Helsinki",60.254435,25.074825
+"Itätuulenkuja 1, Espoo",60.173804,24.803129
+"Ilmarinkatu 1, Helsinki",60.171864,24.922894
+"Siilitie 1, Helsinki",60.207694,25.045875
+"Turuntie 42, Espoo",60.219031,24.828827
+"Tarhurintie 1, Vantaa",60.312866,25.043306
+"Sale Kirkkonummi, Kirkkonummi",60.125235,24.437285
+"Säterinkatu 6, Espoo",60.213837,24.809567
+"Rasinkatu 10, Vantaa",60.323129,25.065167
+"Annankatu 32, Helsinki",60.16839,24.934523
+"Mannerheimintie 100, Helsinki",60.18861,24.917398
+"Haapaniemenkatu 1, Helsinki",60.18184,24.956184
+"Soittajantie 3, Helsinki",60.240667,24.875848
+"Otaniementie 19, Espoo",60.187328,24.81541
+"Gyldenintie 1, Helsinki",60.158416,24.877261
+"Vuorikatu 19, Helsinki",60.172882,24.947889
+"Lauttasaarentie 1, Helsinki",60.161784,24.892603
+"Jousenkaari 5, Espoo",60.174631,24.788054
+"Isokaari 1, Helsinki",60.158193,24.871407
+"Pirjontie 1, Helsinki",60.234384,24.930117
+"Iso Puistotie 1, Helsinki",60.157493,24.95584
+"Ilkantie 3, Helsinki",60.221726,24.903128
+"Haapaniemenkatu 14, Helsinki",60.179647,24.961351
+"Louhikkotie 1, Helsinki",60.257026,25.081903
+"Haaga-Helia ammattikorkeakoulu, Helsinki",60.246665,25.014853
+"Kauniaisten kaupunginkirjasto, Kauniainen",60.21084,24.725788
+"Kielotie 5, Vantaa",60.288902,25.035259
+"Puunhaltijankuja 2, Vantaa",60.323717,25.042747
+"Vanha Viertotie 9, Helsinki",60.210668,24.886038
+"Airport T2, V5312, Vanda",60.317887,24.966144
+"Mannerheimintie 12, Helsinki",60.167902,24.940683
+"Hilapellontie 4, Helsinki",60.239742,24.836941
+"Kampintori, Helsinki",60.167931,24.931554
+"Nordenskiöldinkatu 20, Helsinki",60.191845,24.924373
+"Lentoasema, Vantaa",60.315781,24.968452
+"Pursimiehenkatu 1, Helsinki",60.160908,24.941445
+"Jaakonkatu 3, Vantaa",60.285062,24.853304
+"Keskuskatu 7, Helsinki",60.169528,24.943573
+"Kämnerintie 7, Helsinki",60.275831,25.027236
+"Huopalahdentie 28, Helsinki",60.210342,24.878604
+"Sörnäisten Rantatie 31, Helsinki",60.187326,24.968919
+"Iso Paja, 2094, Helsinki",60.202617,24.924993
+"Aleksanterinkatu 15, Helsinki",60.169035,24.944776
+"Mannerheimintie 160, Helsinki",60.197725,24.900204
+"Pursimiehenkatu, Helsinki",60.159616,24.938459
+"Päiväkumpu, Vantaa",60.324984,25.100251
+"Tornihaukantie 6, Espoo",60.228417,24.772998
+"Välimerenkatu 9, Helsinki",60.159602,24.917108
+"Rajatie 7, Helsinki",60.263158,25.020551
+"Mannerheimintie 10, Helsinki",60.167549,24.941083
+"Koskelantie 72, Helsinki",60.217377,24.977621
+"Rastasniityntie 1, Espoo",60.232878,24.753639
+"Muurala, Espoo",60.212313,24.640894
+"Laajasalo, Helsinki",60.175209,25.030861
+"Alakiventie 2, Helsinki",60.220926,25.07986
+"Rautkalliontie 1, Vantaa",60.322042,25.06639
+"Panuntie 11, Helsinki",60.221632,24.948218
+"Töölönkatu 1, Helsinki",60.173583,24.931763
+"Kaivopiha / Mannerheimintie 5, Helsinki",60.169806,24.940348
+"Järvenperän koulu, Espoo",60.23911,24.704693
+"Suvilahdenkatu 10, Helsinki",60.187948,24.969079
+"Sörnäinen(M), Helsinki",60.187947,24.963035
+"Kokkokalliontie 9, Helsinki",60.230584,24.851578
+"Ristipellontie 6, Helsinki",60.238335,24.852082
+"Laajalahdentie 21, Helsinki",60.200306,24.878386
+"Junailijankuja 1, Helsinki",60.197481,24.939028
+"Lentoasema, Vantaa",60.315781,24.968452
+"Pasilanraitio 13, Helsinki",60.202235,24.925394
+"Kolkekannaksentie 1, Espoo",60.234432,24.719429
+"Hämeentie 105, Helsinki",60.199489,24.963801
+"Unioninkatu 38, Helsinki",60.171484,24.950391
+"Niipperi, Espoo",60.288127,24.74004
+"Meri-Rastilan Tie 1, Helsinki",60.204918,25.117806
+"Myllypuron metroasema, Helsinki",60.224594,25.076641
+"Heinjoenpolku 1, Espoo",60.203837,24.802889
+"Juhana Herttuan tie, 3089, Helsinki",60.21953,24.967777
+"A.i. Virtasen Aukio 1, Helsinki",60.205499,24.963825
+"Tikkurilantie 140, Vantaa",60.301801,24.939917
+"Vanha Porvoontie 229, Vantaa",60.295126,25.086311
+"Mannerheimintie, Helsinki",60.187696,24.918749
+"Museokatu 44, Helsinki",60.175137,24.919694
+"Maamiehentie 2, Helsinki",60.266038,25.058668
+"Soukanniementie 1, Espoo",60.129123,24.67926
+"Niemenmäki, Helsinki",60.206071,24.885243
+"Sturenkatu 21, Helsinki",60.192325,24.953493
+"Jakomäentie, Helsinki",60.25535,25.069746
+"Itämerentori 2, Helsinki",60.163913,24.913627
+"Kaivosrinteentie, Vantaa",60.27009,24.870676
+"Kyyhkysmäki 2, Espoo",60.228494,24.813248
+"Karantie 2, Espoo",60.21527,24.759863
+"TOLSA, Kirkkonummi",60.11779,24.470714
+"Jarrumiehenkatu 2, Helsinki",60.201529,24.940596
+"Piilipuuntie 1, Espoo",60.184789,24.740604
+"Paraistentie 19, Helsinki",60.204122,24.903729
+"Mannerheimintie 15, Helsinki",60.180495,24.928911
+"Puosunrinne 1, Espoo",60.148884,24.646157
+"Rautalammintie 2, Helsinki",60.196418,24.954483
+"Mannerheimintie 170, Helsinki",60.203959,24.89856
+"Ratsastie 10, Helsinki",60.198749,24.910459
+"Rummunlyöjänkatu 3, Espoo",60.217794,24.806053
+"Roihuvuorentie 20, Helsinki",60.200746,25.058359
+"Rautatientori, Helsinki",60.171283,24.942572
+"Suovakuja 1, Helsinki",60.241655,24.922992
+"Palkkatilankatu 9, Helsinki",60.196963,24.923707
+"Venuksentie 6, Vantaa",60.343684,25.096677
+"Mannerheimintie 55, Helsinki",60.190179,24.916054
+"Taimistontie 2, Helsinki",60.218032,24.866878
+"Leppäsuonkatu 11, Helsinki",60.169462,24.921531
+"Kapteeninkatu 1, Helsinki",60.155933,24.946116
+"Käpylänkuja 1, Helsinki",60.215084,24.956931
+"Kaivomestarinkatu, Espoo",60.208989,24.662027
+"Viikinkaari, Helsinki",60.226277,25.015755
+"Kivenlahdenkatu 1, Espoo",60.155809,24.630993
+"Keilaranta 21, Espoo",60.178947,24.83667
+"Kaisaniemenkatu 1, Helsinki",60.170671,24.946061
+"Lehtisaarentie 1, Helsinki",60.180663,24.850044
+"Länsimäki, Vantaa",60.243188,25.117151
+"Alppikatu 15, Helsinki",60.185538,24.945602
+"Itämerenkatu 11, Helsinki",60.16381,24.915652
+"Huovitie 5, Helsinki",60.222291,24.904175
+"Mannerheimintie 166, Helsinki",60.200908,24.897564
+"Ulappakatu 1, Espoo",60.150509,24.655734
+"Vanha Viertotie 1, Helsinki",60.209549,24.888564
+"Landbo, Helsinki",60.269416,25.19459
+"Timpurinkuja 1, Espoo",60.22284,24.814112
+"Vanhanlinnantie 1, Helsinki",60.213659,25.087866
+"Ruoholahdenkatu 14, Helsinki",60.165311,24.927146
+"Vaskihuhdantie, Helsinki",60.274278,25.00547
+"Töölönlahdenkatu 3, Helsinki",60.173773,24.939287
+"Haapaniemenkatu 6, Helsinki",60.181581,24.959229
+"Liisankatu 13, Helsinki",60.174526,24.956602
+"Koivukyläntie 51, Vantaa",60.315936,25.038324
+"Adolf Lindforsin Tie 1, Helsinki",60.229725,24.894364
+"Piilipuuntie 21, Espoo",60.187972,24.739231
+"Laajalahti, Espoo",60.198862,24.838751
+"Ratamestarinkatu 7, Helsinki",60.199808,24.940141
+"Ojahaantie 5, Vantaa",60.265678,24.85942
+"Pietarinkatu 15, Helsinki",60.157383,24.946386
+"Otsonkallio 3, Espoo",60.179742,24.817321
+"Otahalli, Espoo",60.184212,24.835262
+"Pelastusasema 3, Vantaa",60.323251,24.920778
+"Ruosilantie 2, Helsinki",60.237556,24.857805
+"OP Tullinpuomi, Helsinki",60.190863,24.913089
+"Katajanokanlaituri 7, Helsinki",60.165942,24.964381
+"Runeberginkatu, Helsinki",60.169779,24.926741
+"Tikkurilantie 148, Vantaa",60.300266,24.924973
+"Töölönkatu 28, Helsinki",60.178211,24.926135
+"Klariksentie 2, Espoo",60.184184,24.740952
+"Sturenkatu 11, Helsinki",60.18842,24.946107
+"Valimopolku 4, Helsinki",60.221671,24.874821
+"Pirkkolan urheilup., Helsinki",60.232544,24.910059
+"Sepontie 2, Espoo",60.187397,24.790857
+"Kulttuuritalo, Helsinki",60.188292,24.944199
+"Kluuvikatu 8, Helsinki",60.169461,24.946804
+"Tali, Helsinki",60.211975,24.859626
+"Sörkka, Helsinki",60.180718,24.955042
+"Huovitie 1, Helsinki",60.222505,24.905805
+"Tikkurilan urheilupuisto, Vantaa",60.299721,25.026506
+"Porvoonkatu, Helsinki",60.190505,24.945531
+"Kivihaantie 7, Helsinki",60.212156,24.905093
+"Pohjoinen Hesperiankatu 23, Helsinki",60.177263,24.920677
+"Rautalammintie 5, Helsinki",60.197543,24.951743
+"Eteläranta 10, Helsinki",60.165293,24.952021
+"Ulvilantie 21, Helsinki",60.209201,24.868499
+"Espoonlahden koulu ja lukio, Espoo",60.144601,24.664133
+"Matinkatu 1, Espoo",60.160601,24.7476
+"Karhunkierros, Vantaa",60.258035,24.810902
+"Uudenmaankatu 16, Helsinki",60.163902,24.939906
+"Mikonkatu 15, Helsinki",60.171186,24.945633
+"Iso Roobertinkatu, Helsinki",60.162943,24.939272
+"Kaikukatu, Helsinki",60.182643,24.95981
+"Kala-Maija 1, Espoo",60.1595,24.740953
+"Latokartanonkaari 7, Helsinki",60.228687,25.018224
+"Maakirjantie 2, Espoo",60.183912,24.743441
+"Pohjoinen Rautatiekatu 9, Helsinki",60.17169,24.932459
+"Mäkelänkatu 86, Helsinki",60.212318,24.942988
+"Askisto, Vantaa",60.282495,24.776896
+"Kanneltalo, Helsinki",60.238902,24.875959
+"Hämeenkylä, Vantaa",60.268342,24.781205
+"Nordenskiöldinkatu, Helsinki",60.191398,24.924428
+"Koivu-Mankkaan Tie 1, Espoo",60.17463,24.779941
+"Malminiitty, Vantaa",60.314627,25.037656
+"Mannerheimintie 9, Helsinki",60.170488,24.938321
+"Valimotie 21, Helsinki",60.220308,24.879477
+"Paulankatu 2, Helsinki",60.193817,24.929281
+"Pohjois-Haagan yhteiskoulu, Helsinki",60.226765,24.897688
+"Osmontie 43, Helsinki",60.218724,24.946576
+"Ojahaantie 1, Vantaa",60.264332,24.859472
+"Paciuksenkaari 1, Helsinki",60.19693,24.898793
+"Harustie 8, Helsinki",60.202881,25.122379
+"Von Daehnin Katu 8, Helsinki",60.231125,25.046322
+"Revontulentie 7, Espoo",60.172731,24.806139
+"Karsikkokuja 15, Vantaa",60.319507,25.059478
+"Vilniementie 1, Espoo",60.234791,24.723595
+"Havukoski, Vantaa",60.317924,25.070136
+"Kilonportti 1, Espoo",60.219354,24.784301
+"Naalitie, Vantaa",60.349945,25.086736
+"Kutomotie 4, Helsinki",60.214226,24.874887
+"Kilonkallio 10, Espoo",60.221983,24.778743
+"Nordenskiöldinkatu 18, Helsinki",60.191529,24.920262
+"Sentnerikuja 1, Helsinki",60.22827,24.878023
+"Talin Puistotie 1, Helsinki",60.217765,24.867618
+"Dynamicum, Helsinki",60.203835,24.960893
+"Radiokatu 20, Helsinki",60.203729,24.918136
+"Tiimalasintie 1, Espoo",60.168129,24.612204
+"Sturenkatu 40, Helsinki",60.196423,24.95948
+"Länsituulentie, Espoo",60.175589,24.803337
+"Kamppi, Helsinki",60.16902,24.931702
+"Karakalliontie 1, Espoo",60.227324,24.759817
+"Kaj Franckin Katu 1, Helsinki",60.20828,24.979498
+"Strömberginkuja 3, Helsinki",60.222252,24.863444
+"Kampen, Helsingfors",60.168438,24.929283
+"Harjannetie 44, Helsinki",60.224619,24.989597
+"Alppikatu 5, Helsinki",60.185031,24.941828
+"Teollisuuskatu 15, Helsinki",60.193732,24.950411
+"Kontulankaari 11, Helsinki",60.245066,25.079025
+"Heikkiläntie 7, Helsinki",60.15616,24.884639
+"Kalastajanmäki 1, Espoo",60.154416,24.729391
+"Alaportti 1, Espoo",60.175109,24.732903
+"Hämeentie 19, Helsinki",60.185795,24.962214
+"Lintuvaara, Espoo",60.237785,24.796922
+"Eira, Helsinki",60.156455,24.937049
+"Näyttelijäntie 14, Helsinki",60.229643,24.896174
+"Maakaari 1, Helsinki",60.229932,25.024578
+"Lämmittäjänkatu 2, Helsinki",60.199356,25.038342
+"Porttipuistontie 1, Vantaa",60.279797,25.082106
+"Myyrmäentie 4, Vantaa",60.266671,24.852484
+"Latokartano, Helsinki",60.226243,25.029124
+"Arkadiankatu 26, Helsinki",60.171234,24.922248
+"Vitikka 1, Espoo",60.208718,24.762819
+"Tunturikatu 16, Helsinki",60.174025,24.923839
+"Sturenkatu 13, Helsinki",60.189157,24.947251
+"Viikintori 3, Helsinki",60.227528,25.008561
+"Lehtikuusentie 6, Helsinki",60.196445,24.907845
+"Väinö Tannerin Tie 1, Vantaa",60.292885,24.95698
+"Servin Maijan Tie 12, Espoo",60.190931,24.83743
+"Perhonkatu 11, Helsinki",60.170814,24.921265
+"Tapionaukio, Espoo",60.176351,24.806392
+"Karvaamokuja, Helsinki",60.215817,24.881089
+"Mannerheimintie, Helsinki",60.187696,24.918749
+"Urho Kekkosen Katu 1, Helsinki",60.169813,24.935317
+"Varisto, Vantaa",60.271141,24.812858
+"Tilkankatu 1, Helsinki",60.203997,24.895237
+"Tyynenmerenkatu 1, Helsinki",60.159903,24.920915
+"Kylävainiontie 20, Espoo",60.21007,24.676917
+"Aleksis Kiven Katu 9, Helsinki",60.189761,24.953256
+"Ruorimiehenkatu 1, Espoo",60.148588,24.651241
+"Kirstintie 1, Espoo",60.200517,24.665935
+"Serkustentie 1, Helsinki",60.254453,24.897764
+"Laaksolahti, Espoo",60.240198,24.757427
+"Ämmässuon kaatopaikka, Espoo",60.238449,24.535416
+"Palkkatilankatu 1, Helsinki",60.19576,24.927192
+"Latokartanontie 16, Helsinki",60.244636,25.015038
+"Urheilupuisto, Espoo",60.174559,24.781082
+"Elimäenkatu 15, Helsinki",60.194533,24.94991
+"Sturenkatu, Helsinki",60.190843,24.948729
+"Sotungin koulu, Vantaa",60.280261,25.12137
+"Kalastajankuja 1, Espoo",60.153118,24.731246
+"Pajuniityntie 10, Helsinki",60.218485,24.905465
+"Lummetie, Vantaa",60.297379,25.031305
+"Haapaniemenkatu 4, Helsinki",60.181808,24.958188
+"Helsingin luonnontiedelukio, Helsinki",60.210268,24.943388
+"Kaj Franckin Katu 4, Helsinki",60.208501,24.980459
+"Vesirattaanmäki 1, Espoo",60.227324,24.666557
+"Ida Aalbergin tie 3, Helsinki",60.23048,24.89897
+"Vaarala, Vantaa",60.264818,25.096948
+"Sauvatie, Vantaa",60.31977,25.073512
+"Näkinkuja 3, Helsinki",60.18031,24.953664
+"Urheilukatu, Helsinki",60.188153,24.920234
+"Paraistentie 18, Helsinki",60.203942,24.903163
+"Siilitien metroasema, Helsinki",60.205729,25.043849
+"Sanomatalo, Helsinki",60.172453,24.937875
+"Mäkelänkatu 47, Helsinki",60.19877,24.949159
+"Brysselinkatu 3, Helsinki",60.202851,24.972163
+"Sörnäisten Rantatie 1, Helsinki",60.180095,24.952524
+"Kivihaka, Helsinki",60.210094,24.903496
+"Samarian terveyskeskus, Espoo",60.201996,24.654193
+"Pihlajisto, Helsinki",60.231024,25.001334
+"Mechelininkatu, Helsinki",60.173492,24.919133
+"Haapaniemi, Helsinki",60.182614,24.957219
+"Viikin kirjasto, Helsinki",60.227529,25.013025
+"Pohjoinen Rautatiekatu 29, Helsinki",60.168938,24.924196
+"Maakaari 6, Helsinki",60.23055,25.025119
+"Pasilanraitio 5, Helsinki",60.197714,24.927502
+"Nauvontie 3, Helsinki",60.206797,24.901916
+"Hämeentie 152, Helsinki",60.211612,24.976514
+"Mäkelänrinne 5, Helsinki",60.198532,24.950653
+"Tukkitie 18, Helsinki",60.271769,25.072921
+"Matinniitty 1, Espoo",60.159836,24.745904
+"Pasilankatu 2, Helsinki",60.195583,24.928466
+"Ulvilantie 27, Helsinki",60.208911,24.875649
+"Työpajankatu 2, Helsinki",60.190445,24.972473
+"Betonimiehenkuja 5, Espoo",60.180984,24.831683
+"Puumiehenkuja 2, Espoo",60.186964,24.824994
+"Maauunintie 19, Vantaa",60.344388,25.059595
+"Servinkuja 1, Espoo",60.190276,24.835237
+"Killinmäki, Kirkkonummi",60.131775,24.479459
+"Paavo Nurmen Kuja 1, Helsinki",60.183398,24.925826
+"Rastilan metroasema, Helsinki",60.20566,25.120476
+"Puutarhurinkuja 2, Helsinki",60.207879,24.893653
+"Viikin normaalikoulu, Helsinki",60.2277,25.030158
+"Vantaankosken koulu, Vantaa",60.293324,24.852601
+"Suursuon sairaala, Helsinki",60.234874,24.932495
+"Majurinkatu 12, Espoo",60.216679,24.825643
+"Tiedekirjasto, Helsinki",60.20495,24.962143
+"Liikuntamylly, Helsinki",60.224634,25.077394
+"Kumpulantie 3, Helsinki",60.196467,24.942014
+"Sturenkatu 8, Helsinki",60.189425,24.946585
+"Tähkäkuja, Vantaa",60.29979,25.061946
+"Nahkahousuntie 5, Helsinki",60.151038,24.883977
+"Pajuniityntie 1, Helsinki",60.216706,24.906012
+"Ahertajantie, Espoo",60.178694,24.797883
+"Pälkäneentie 13, Helsinki",60.195149,24.950269
+"Verkkokauppa.com, Helsinki",60.156464,24.921045
+"Sörnäisten Rantatie 33, Helsinki",60.187948,24.969079
+"Pietari Hannikaisen Tie 1, Helsinki",60.225878,24.897554
+"Aleksis Kiven katu, Helsinki",60.193112,24.94363
+"Asemakuja 1, Espoo",60.20445,24.659754
+"Mannerheimintie 96, Helsinki",60.187998,24.917924
+"Gustaf Hällströmin Katu 2, Helsinki",60.204867,24.963034
+"Kylmäojantie 4, Vantaa",60.321176,25.015536
+"Exactum, Helsinki",60.20442,24.961769
+"Jaakonkatu 3, Helsinki",60.169928,24.931759
+"Pasilan poliisitalo, Helsinki",60.20224,24.925345
+"Alppikatu 1, Helsinki",60.183856,24.940783
+"Strömbergintie 1, Helsinki",60.221612,24.867765
+"Porkkalankatu 22, Helsinki",60.163958,24.909064
+"Alvar Aallon Katu 1, Helsinki",60.176383,24.938511
+"Muotoilijankatu 3, Helsinki",60.21004,24.978253
+"Tekniikantie 14, Espoo",60.185407,24.812273
+"Työväen akatemia, Kauniainen",60.222279,24.71712
+"Kulomäki, Vantaa",60.342932,25.059943
+"Munkkiniemen Yhteiskoulu, Helsinki",60.20028,24.878331
+"Vasamatie 1, Espoo",60.211698,24.770197
+"Columbus, Helsinki",60.207402,25.145805
+"Siilitie 13, Helsinki",60.213648,25.043969
+"Pasilanraitio 4, Helsinki",60.196435,24.926103
+"Pohjois-Haagan asema, Helsinki",60.229909,24.883091
+"Liisankuja 2, Espoo",60.15304,24.744045
+"Itälahdenkatu, Helsinki",60.15067,24.88115
+"Ravals, Kirkkonummi",60.129131,24.41735
+"Urheilukatu 1, Helsinki",60.187822,24.921001
+"Ohratie 16, Vantaa",60.299691,25.066028
+"Peltokyläntie 1, Helsinki",60.267606,24.980777
+"Purotie 1, Helsinki",60.217264,24.868842
+"Läkkisepäntie 23, Helsinki",60.220485,24.943722
+"Kankaretie, Helsinki",60.258352,25.081707
+"Töölöntorinkatu 2, Helsinki",60.177692,24.924509
+"Runeberginkatu, Helsinki",60.167871,24.93012
+"Revontulentie 1, Espoo",60.173237,24.809603
+"Malmitalo, Helsinki",60.250526,25.014631
+"Viipurinkatu 1, Helsinki",60.190905,24.946511
+"Tapionaukio 3, Espoo",60.177334,24.807473
+"Suursuonlaita 3, Helsinki",60.234866,24.932236
+"Itäviitta 5, Espoo",60.167025,24.615745
+"Ohjaajantie 1, Helsinki",60.227854,24.894719
+"Pekankatu 5, Helsinki",60.251014,25.013929
+"Otakaari 24, Espoo",60.185207,24.832342
+"Otakaari 18, Espoo",60.188193,24.83532
+"Itätuulentie 1, Espoo",60.173548,24.802316
+"Aleksis Kiven Katu 48, Helsinki",60.191095,24.947707
+"Vanha Nurmijärventie 21, Vantaa",60.281768,24.877542
+"Vallilan kirjasto, Helsinki",60.192281,24.961126
+"Kirkkojärven koulu, Espoo",60.209386,24.664426
+"Point, V5119, Vantaa",60.286042,24.95756
+"Nosturi, Helsinki",60.15973,24.93097
+"Siltamäki, Helsinki",60.278148,24.983344
+"Malminkartanon asema, Helsinki",60.249216,24.861327
+"Martinsillantie 10, Espoo",60.159939,24.696046
+"Ala-Malmin Tori 1, Helsinki",60.250505,25.014719
+"Lumon lukio, Vantaa",60.351641,25.076592
+"Louhelantie 1, Vantaa",60.269771,24.8587
+"Bunkkeri, Helsinki",60.155585,24.920821
+"Karaportti 3, Espoo",60.225042,24.758239
+"Muurikuja 1, Helsinki",60.195318,24.972935
+"Talvikkitie 119, Vantaa",60.318201,25.052421
+"Näyttelijäntie 24, Helsinki",60.232519,24.892703
+"Hevosmiehenkatu 1, Helsinki",60.255276,25.064095
+"Eestinlaakso, Espoo",60.166738,24.676373
+"Havukosken koulu, Vantaa",60.318569,25.078077
+"Niemitie 1, Helsinki",60.266237,24.980482
+"Vanha Talvitie 14, Helsinki",60.192528,24.975506
+"Lastenlinnantie 2, Helsinki",60.185792,24.909533
+"Tapiolan uimahalli, Espoo",60.1784,24.807558
+"Vanha Turuntie 1, Espoo",60.224117,24.721356
+"Bulevardi, Helsinki",60.164875,24.936378
+"Mannerheimintie 29, Helsinki",60.185611,24.922043
+"Kurkisuontie 9, Helsinki",60.232938,25.065268
+"Hevosenkenkä 3, Espoo",60.21811,24.814337
+"Rajatorpantie 8, Vantaa",60.258431,24.852301
+"Liisankatu 1, Helsinki",60.174499,24.960697
+"Tyynenmerenkatu 7, Helsinki",60.157319,24.921541
+"Roihuvuori, Helsinki",60.205502,25.066329
+"Läkkisepäntie 21, Helsinki",60.219968,24.942833
+"Porvoonkatu 3, Helsinki",60.189015,24.951463
+"Käpyläntie 11, Helsinki",60.217923,24.962224
+"Hämeentie 2, Helsinki",60.180285,24.950563
+"TF, Espoo",60.186015,24.832932
+"Maininkitie 1, Espoo",60.150367,24.645654
+"Merivalkama 1, Espoo",60.154313,24.633713
+"Urheilukatu 5, Helsinki",60.187381,24.922039
+"Espoon kulttuurikeskus, Espoo",60.1779,24.804333
+"Servin Maijan Tie 1, Espoo",60.18891,24.835237
+"Eskolantie 1, Helsinki",60.243906,24.99454
+"Toinen Linja 14, Helsinki",60.183856,24.940783
+"Eerikinkatu 24, Helsinki",60.16605,24.932507
+"Opastinsilta 6, Helsinki",60.199087,24.940641
+"Viikinkaari 9, Helsinki",60.227092,25.014835
+"Paasivuorenkatu 5, Helsinki",60.178752,24.947594
+"Maistraatinportti 3, Helsinki",60.198893,24.925876
+"Siltapellonkuja 2, Helsinki",60.269189,24.989774
+"Simonkatu 1, Helsinki",60.170384,24.93685
+"Viikinportti 2, Helsinki",60.226651,25.008181
+"Väinö Auerin Katu 11, Helsinki",60.205626,24.961597
+"Siltavoudintie 24, Helsinki",60.236115,24.963659
+"Viljelijäntie, Helsinki",60.242983,24.856902
+"Malmin Kauppatie 18, Helsinki",60.251904,25.010369
+"Mannerheimintie, Helsinki",60.187696,24.918749
+"Kauniaisten asema, Kauniainen",60.211991,24.731546
+"Pasilanraitio 1, Helsinki",60.196325,24.928257
+"Espoontie 21, Espoo",60.215825,24.662951
+"Virtatie 4, Vantaa",60.266231,24.851374
+"Talonpojantie 5, Helsinki",60.230059,25.023451
+"Moisiontie 3, Helsinki",60.26983,25.030743
+"Metro Sörnäinen, Helsinki",60.187821,24.961115
+"Televisiokatu 1, Helsinki",60.204557,24.925663
+"Martinlaakson liikuntapuisto, Vantaa",60.283163,24.84867
+"Kuikkakuja 1, Vantaa",60.356971,25.050399
+"Pirkkola, Helsinki",60.234255,24.914395
+"Valimotie 27, Helsinki",60.22162,24.876684
+"Kirkkokatu 1, Espoo",60.207155,24.661835
+"Rautatieläisenkatu 5, Helsinki",60.201841,24.935217
+"Koivukylän koulu, Vantaa",60.324613,25.076512
+"Soukankaari 1, Espoo",60.141595,24.672851
+"Arabiankatu 2, Helsinki",60.207275,24.97485
+"Ahertajantie 2, Espoo",60.178288,24.798093
+"Tilanhoitajankaari 6, Helsinki",60.23243,25.031345
+"JORVAS, Kirkkonummi",60.137887,24.512381
+"Turvalaaksontie 1, Vantaa",60.301331,24.884816
+"Kankaretie, Helsinki",60.258352,25.081707
+"Tietotie 9, Vantaa",60.309085,24.964386
+"Kinopalatsi, Helsinki",60.171132,24.946264
+"Karaportti 1, Espoo",60.224711,24.756672
+"Teollisuuskatu, Helsinki",60.193582,24.948639
+"Ympyrätalo, Helsinki",60.180279,24.948949
+"Itämerenkatu 1, Helsinki",60.164174,24.920513
+"Kaivokatu 8, Helsinki",60.169961,24.941419
+"Töölön halli, Helsinki",60.185764,24.921327
+"Linnankatu 9, Helsinki",60.165759,24.969998
+"Syystie 1, Helsinki",60.251774,24.99395
+"Lähettilääntie 1, Vantaa",60.284476,24.959748
+"Esport Center, Espoo",60.175551,24.781485
+"Mechelininkatu 36, Helsinki",60.180072,24.914224
+"Alempi Talonpojantie 4, Helsinki",60.226427,25.022622
+"Pieni Roobertinkatu 12, Helsinki",60.164075,24.94538
+"Keilaranta 14, Espoo",60.178407,24.832863
+"Kauppakeskus Arabia, Helsinki",60.202747,24.968002
+"Keilaniemi, Espoo",60.175648,24.829476
+"Ratatie, Vantaa",60.297053,25.045573
+"Mikonkatu 1, Helsinki",60.168047,24.945937
+"Kullervonkatu 11, Helsinki",60.218663,24.948458
+"Malmin hautausmaa, Helsinki",60.237165,25.025414
+"Kulttuuriaukio 2, Espoo",60.178086,24.804628
+"Miestentie 3, Espoo",60.178462,24.829072
+"Uutiskatu 5, Helsinki",60.203802,24.921622
+"Ilkantie 1, Helsinki",60.220045,24.902441
+"Helsinki-Malmin lentoasema, Helsinki",60.252,25.0448
+"Erätie 3, Helsinki",60.265614,25.019028
+"Eiran aikuislukio, Helsinki",60.155683,24.942685
+"Runeberginkatu 1, Helsinki",60.168131,24.93061
+"Rautatieasema, Helsinki",60.170337,24.941295
+"Linnoituksentie 2, Helsinki",60.240674,25.070394
+"Mannerheimintie 5, Helsinki",60.169563,24.940038
+"Munkkivuoren ostosk., 1432, Helsinki",60.205399,24.877242
+"Hämeentie 157, Helsinki",60.212787,24.979347
+"Ruusulankatu 1, Helsinki",60.181469,24.925966
+"Vaasankatu 2, Helsinki",60.187815,24.959852
+"Yrjönkatu 30, Helsinki",60.167764,24.937555
+"Silmupolku 1, Helsinki",60.217765,24.867618
+"Tikkurilan uimahalli, Vantaa",60.299024,25.030343
+"Avaruuskatu 4, Espoo",60.169589,24.725838
+"Opastinsilta 1, Helsinki",60.200149,24.943118
+"Fabianinkatu 26, Helsinki",60.170844,24.947962
+"Kirurginen sairaala, Helsinki",60.161659,24.949068
+"Sports car center, Espoo",60.180618,24.760568
+"Mannerheimintie 93, Helsinki",60.196227,24.903709
+"Jämeräntaival 10, Espoo",60.190289,24.838808
+"Mäkelänrinteen uintikeskus, Helsinki",60.199787,24.948075
+"Savonkatu 4, Helsinki",60.195031,24.935122
+"Haapaniemenkatu 16, Helsinki",60.179226,24.960836
+"Opastinsilta 2, Helsinki",60.199669,24.942878
+"Valimotie 9, Vantaa",60.273252,24.972834
+"Eiran sairaala, Helsinki",60.158167,24.941606
+"Salomonkatu 1, Helsinki",60.170848,24.934928
+"Keilaranta 1, Espoo",60.176396,24.830687
+"Wanha Satama, Helsinki",60.165529,24.96764
+"Akanapolku, Vantaa",60.299655,25.060964
+"Meripihkatie 1, Helsinki",60.233769,25.012119
+"Varsapuistikko, Helsinki",60.173587,24.949629
+"Helmipöllönkatu 1, Espoo",60.239868,24.821595
+"Ratakatu 6, Helsinki",60.162818,24.944119
+"Haartmaninkatu 3, Helsinki",60.190516,24.909503
+"Hietaniemenkatu 14, Helsinki",60.169429,24.922867
+"Tennispuisto, Espoo",60.172238,24.801904
+"Rosendalinkuja 1, Vantaa",60.267978,24.966308
+"Valimotie 9, Helsinki",60.217164,24.878886
+"Kilon asema, Espoo",60.217879,24.781975
+"Matinniitynkuja 1, Espoo",60.160126,24.745001
+"Kirstinharju 3, Espoo",60.201673,24.665744
+"Turuntie 150, Espoo",60.22221,24.685375
+"Kyyhkysmäki 1, Espoo",60.228942,24.813218
+"Kaivokatu 2, Helsinki",60.170155,24.944039
+"Helsinginkatu, Helsinki",60.187527,24.95329
+"Kauklahden asema, Espoo",60.189243,24.599821
+"Arielinkatu 2, Helsinki",60.186014,24.981805
+"Sinikalliontie 1, Espoo",60.204992,24.767187
+"Helsinginkatu 58, Helsinki",60.181646,24.929795
+"Mechelininkatu, Helsinki",60.173492,24.919133
+"Myrskyläntie 1, Helsinki",60.221159,24.967097
+"Berliininkatu 5, Helsinki",60.203984,24.974024
+"Fleminginkatu 1, Helsinki",60.183633,24.953674
+"Hämeentie 68, Helsinki",60.190428,24.963857
+"Sturenkatu 27, Helsinki",60.193687,24.956223
+"Simonkylän koulu, Vantaa",60.316475,25.035306
+"Viides Linja 1, Helsinki",60.18255,24.955689
+"Vanhaistentie 4, Helsinki",60.242715,24.883737
+"Mäkelänkatu 1, Helsinki",60.190428,24.963857
+"Intiankatu 21, Helsinki",60.208333,24.967692
+"Uimastadion, Helsinki",60.18885,24.930479
+"Saunalahden koulu, Espoo",60.168946,24.614796
+"Holmankorpi 1, Espoo",60.174261,24.710243
+"Jupperi, Espoo",60.254171,24.763981
+"Maistraatinportti 1, Helsinki",60.199063,24.92702
+"Toinen Linja 1, Helsinki",60.180679,24.951387
+"Valtimontie 1, Helsinki",60.214517,24.965053
+"Eläintarha, Helsinki",60.192507,24.93053
+"Koskelantie 3, Helsinki",60.207814,24.941574
+"Mäkipellontie 19, Helsinki",60.220744,24.898406
+"Terminaali 2, Vantaa",60.318187,24.966239
+"Alppilan yläaste ja lukio, Helsinki",60.192525,24.939665
+"Lehtisaari, Helsinki",60.180421,24.850974
+"Siilitie 11, Helsinki",60.212788,25.04171
+"Hagelstamintie 1, Vantaa",60.284894,24.958293
+"Salmisaarenaukio 1, Helsinki",60.165313,24.901047
+"Haukilahti, Espoo",60.162081,24.776125
+"Kansallismuseo, Helsinki",60.174788,24.932546
+"Fazerintie 6, Vantaa",60.25419,25.103918
+"Väinö Auerin Katu 13, Helsinki",60.205091,24.960674
+"Kallion virastotalo, Helsinki",60.18055,24.949722
+"Porkkalankatu 13, Helsinki",60.163302,24.901103
+"Vantaankosken asema, Vantaa",60.285823,24.848079
+"Ylästö, Vantaa",60.282543,24.915923
+"Hiomotie 13, Helsinki",60.221149,24.873067
+"Tehtaankatu, Helsinki",60.158196,24.94469
+"Kirstinmäki 7, Espoo",60.20248,24.665182
+"Iiluodontie, Helsinki",60.205982,25.145125
+"Vallila, Helsinki",60.196804,24.956823
+"Von Daehnin Katu 1, Helsinki",60.232737,25.047202
+"Sairaalakatu 1, Vantaa",60.331232,25.059144
+"Onnentie 18, Helsinki",60.219886,24.956722
+"Mäkelänkatu 56, Helsinki",60.197042,24.950096
+"Ratapihantie 11, Helsinki",60.200842,24.934504
+"Mattlidens skola och gymnasium, Espoo",60.16387,24.750421
+"Kutojantie 3, Espoo",60.210455,24.753982
+"Tapiolan keskustorni, Espoo",60.177028,24.804613
+"Kitarakuja 3, Helsinki",60.238467,24.877581
+"Upinniemi, Kirkkonummi",60.029051,24.359927
+"Rasinkatu 20, Vantaa",60.324553,25.066115
+"Haartmanin sairaala, Helsinki",60.189644,24.907637
+"Rosendalinkuja 7, Vantaa",60.267292,24.968972
+"Siltakylänkuja 1, Helsinki",60.269668,24.984628
+"Puolarmetsän sairaala, Espoo",60.176127,24.703541
+"Vanhanlinnantie 3, Helsinki",60.214056,25.088565
+"Porttisuontie 18, Vantaa",60.276864,25.084882
+"Kalastajatorpantie 1, Helsinki",60.192302,24.873329
+"Äyritie 1, Vantaa",60.294477,24.976478
+"A-Link Arena, Espoo",60.210057,24.67698
+"Aalto Puunjalostustekniikka 1, Espoo",60.181649,24.824967
+"Vilppulantie 14, Helsinki",60.250131,25.017922
+"Apollonkatu 1, Helsinki",60.176412,24.928845
+"Kirstinkatu 1, Helsinki",60.18535,24.947381
+"Ulvilantie 19, Helsinki",60.207832,24.864077
+"Kustaankartano, Helsinki",60.228912,24.949204
+"Lastenklinikka, Helsinki",60.186614,24.907858
+"Kurkimäentie 19, Helsinki",60.231521,25.064738
+"Hietakummuntie 1, Helsinki",60.247031,25.01661
+"Agronominkatu 1, Helsinki",60.234281,25.033816
+"Tukholmankatu 8, Helsinki",60.190502,24.904056
+"Tekniikantie 12, Espoo",60.184755,24.812443
+"Aalto Otaniemen kampuskirjasto, Espoo",60.184623,24.827957
+"Isokaari 19, Helsinki",60.158655,24.862691
+"Paciuksenkatu 21, Helsinki",60.194453,24.893251
+"Von Daehnin katu 14, Helsinki",60.230334,25.043824
+"Länsiväylä, Helsinki",60.164287,24.913948
+"Stenbäckinkatu 11, Helsinki",60.186966,24.909368
+"Pitäjänmäentie 35, Helsinki",60.225186,24.849349
+"Laajavuorenkuja 1, Vantaa",60.281458,24.842651
+"Muusantori 5, Helsinki",60.207055,24.855192
+"Hopeatie 10, Helsinki",60.229368,24.884905
+"Ruoholahdenranta 3, Helsinki",60.162357,24.924377
+"Vieraskuja 5, Espoo",60.208008,24.662803
+"Nihtisillankuja 4, Espoo",60.208718,24.762819
+"Postintaival 9, Helsinki",60.215024,24.920705
+"Kolmas Linja 1, Helsinki",60.181276,24.952847
+"Laivurinkatu 3, Helsinki",60.155657,24.9428
+"Marian sairaala, Helsinki",60.167493,24.921329
+"Oulunkylän yhteiskoulu, Helsinki",60.23591,24.96346
+"Ahertajantie 5, Espoo",60.179008,24.794684
+"Bulevardi 1, Helsinki",60.166532,24.942697
+"Intiankatu 20, Helsinki",60.207394,24.967371
+"Ulvilantie 17, Helsinki",60.205029,24.865413
+"Aleksanterin teatteri, Helsinki",60.163578,24.935036
+"Nuijamiestentie 10, Helsinki",60.218201,24.906856
+"Thalianaukio, Helsinki",60.22506,24.895554
+"Talkoorinne 1, Espoo",60.202829,24.687625
+"Kaupintie 3, Helsinki",60.233343,24.886347
+"Vanha Maantie 1, Espoo",60.221283,24.809575
+"Sello, Espoo",60.217826,24.812706
+"Ensi Linja 1, Helsinki",60.183325,24.941286
+"Kolmas Linja 17, Helsinki",60.183083,24.94828
+"Lönnrotinkatu 13, Helsinki",60.165839,24.936252
+"Helsingin kielilukio, Helsinki",60.213185,25.071066
+"Rörstrandinkatu 3, Helsinki",60.205938,24.977874
+"Lassila, Helsinki",60.231267,24.86874
+"Vironkatu 2, Helsinki",60.172214,24.958098
+"Kunnalliskodintie 6, Helsinki",60.217282,24.967264
+"Ericsson, Ki0313, Kirkkonummi",60.131883,24.513693
+"Yliopistonkatu 3, Helsinki",60.170223,24.948433
+"Töölöntullinkatu 8, Helsinki",60.190241,24.912587
+"Revontulenkuja 1, Espoo",60.170274,24.803707
+"Urheilutalo, Helsinki",60.18749,24.948514
+"Kulorastaantie 1, Vantaa",60.345689,25.058267
+"Viikinkaari 5, Helsinki",60.226199,25.016406
+"Pähkinärinne, Porvoo",60.341898,25.484049
+"Käenkuja, Helsinki",60.18557,24.960857
+"Kallion lukio, Helsinki",60.183329,24.956161
+"Fleminginkatu 34, Helsinki",60.190659,24.951469
+"Pasteurinkatu 1, Helsinki",60.224585,25.013596
+"Hämeentie 161, Helsinki",60.213998,24.980464
+"Jämeräntaival 11, Espoo",60.189368,24.83903
+"Topeliuksenkatu 5, Helsinki",60.181413,24.922362
+"Suomenoja, Espoo",60.158526,24.71069
+"Isonnevantie 8, Helsinki",60.212013,24.889308
+"Nissas, V9429, Vantaa",60.28676,25.123784
+"Kemistintie 1, Espoo",60.183645,24.824726
+"Kaikukatu 4, Helsinki",60.183394,24.960307
+"Kokkokalliontie 1, Helsinki",60.228495,24.850703
+"Pikkuparlamentti, Helsinki",60.171429,24.933934
+"Ulvilantie 29, Helsinki",60.206777,24.877535
+"Ilmalantori 2, Helsinki",60.206731,24.918848
+"Mäkelänkatu 49, Helsinki",60.199776,24.948031
+"Vantaanportinkatu 3, Vantaa",60.290952,24.965622
+"Kutomokuja 4, Helsinki",60.213492,24.875621
+"Ympyrätalon apteekki, Helsinki",60.180111,24.949388
+"Tammisto, Vantaa",60.274288,24.958885
+"Hostel Diana Park (Erottajanpuisto), Helsinki",60.164934,24.941784
+"Sotungin lukio, Vantaa",60.279435,25.121763
+"Kutojantie 1, Espoo",60.209611,24.755105
+"Viljelijäntie, Helsinki",60.243402,24.858613
+"Majurinkulma 2, Espoo",60.211455,24.825321
+"Ruoholahden metroasema, Helsinki",60.162633,24.913778
+"Kuunsilta, E3263, Espoo",60.17256,24.72448
+"Original Sokos Hotel Tapiola Garden, Espoo",60.177263,24.80733
+"Pasilanraitio 6, Helsinki",60.197021,24.926265
+"Kapteeninkatu 26, Helsinki",60.159193,24.946075
+"Siltakylänkuja 3, Helsinki",60.269194,24.985959
+"Ulvilantie, Helsinki",60.207171,24.864104
+"Martinlaaksontie 36, Vantaa",60.27482,24.845733
+"Näyttelijäntie 22, Helsinki",60.232472,24.89426
+"Physicum, Helsinki",60.204903,24.962861
+"Koskelan sairaala, Helsinki",60.216377,24.962787
+"Kantvik, Kirkkonummi",60.091621,24.394089
+"Kauppakorkeakoulut, Helsinki",60.171302,24.924927
+"Laakson sairaala, Helsinki",60.192026,24.917634
+"Tikkurilan kirkko, Vantaa",60.292987,25.039443
+"Mäkelänkatu 2, Helsinki",60.190222,24.962138
+"Töölön ala-asteen koulu, Helsinki",60.182693,24.922163
+"Hanken School of Economics, Helsinki",60.17072,24.924522
+"Hämeentie 1, Helsinki",60.180321,24.952636
+"Keilaniementie 1, Espoo",60.17508,24.831008
+"Lapinrinne 1, Helsinki",60.167114,24.927574
+"Kontulan metroasema, Helsinki",60.236261,25.083558
+"Väinö Auerin Katu 3, Helsinki",60.208305,24.964644
+"Helsinki-Vantaa lentoasema T1, Vantaa",60.31542,24.970949
+"Opastinsilta 12, Helsinki",60.199025,24.936062
+"Agricolankatu, Helsinki",60.184241,24.952967
+"Espoonlahti, Espoo",60.150537,24.653068
+"Piispansilta 11, Espoo",60.161529,24.737713
+"Kluuvi, Helsinki",60.174748,24.945821
+"Kuusilahdenkuja 1, Helsinki",60.185305,24.856558
+"Malmin tori, 3263, Helsinki",60.251411,25.008447
+"Tapiolansolmu, Espoo",60.170336,24.810154
+"Suvela, Espoo",60.203553,24.670098
+"Maininkitie 4, Espoo",60.151889,24.644879
+"Siltavuorenpenger 10, Helsinki",60.175314,24.951829
+"Arkadiankatu 21, Helsinki",60.171409,24.925951
+"Rautalammintie 3, Helsinki",60.198315,24.951677
+"Kasarmikatu 13, Helsinki",60.161639,24.949167
+"Kirstinharju 1, Espoo",60.201292,24.665573
+"Valimotie 17, Helsinki",60.219512,24.879673
+"Viikin kampuskirjasto, Helsinki",60.227346,25.012731
+"Hesperian puisto, Helsinki",60.178311,24.929261
+"Telakkakatu 8, Helsinki",60.15871,24.93241
+"Kylänevantie 16, Helsinki",60.213213,24.893004
+"Asema-Aukio 1, Helsinki",60.171198,24.941828
+"Kannelmäen asema, Helsinki",60.23926,24.877981
+"Nikinmäki, Vantaa",60.340203,25.135043
+"Haartmaninkatu 2, Helsinki",60.188804,24.910874
+"Olympiastadion, Helsinki",60.186897,24.927155
+"Riihimäki, Tuusula",60.447428,25.015052
+"Ylioppilastalo, Helsinki",60.168694,24.942461
+"Topeliuksenkatu 41, Helsinki",60.18958,24.912232
+"Tilanhoitajankaari 11, Helsinki",60.230653,25.029573
+"Westend, Espoo",60.163156,24.791657
+"Pariisinkuja 2, Helsinki",60.202382,24.969648
+"Katriinan sairaala, Vantaa",60.345594,24.875237
+"Mellunmäen metroasema, Helsinki",60.238931,25.110256
+"Porkkalankatu 1, Helsinki",60.165472,24.913348
+"Pajamäki, Helsinki",60.219006,24.856691
+"Konemiehentie, Espoo",60.187993,24.82334
+"Maapadontie 2, Helsinki",60.230813,24.947156
+"Juhana Herttuan tie 3, Helsinki",60.217748,24.969732
+"Pihatörmä 1, Espoo",60.165098,24.728978
+"Hanasaari, Espoo",60.163595,24.835892
+"Siltakuja 2, Espoo",60.203391,24.656707
+"Pohjoinen Hesperiankatu 17, Helsinki",60.177368,24.923321
+"Konala, Helsinki",60.237156,24.84774
+"Mäkelänkatu 84, Helsinki",60.210172,24.943646
+"Meilahden liikuntapuisto, Helsinki",60.190046,24.898821
+"Helsinginkatu 1, Helsinki",60.187815,24.959852
+"Ruskeasuon varikko, 1932, Helsinki",60.207034,24.89887
+"Höyläämötie 1, Helsinki",60.214801,24.879417
+"Matinniitynkuja 4, Espoo",60.159434,24.744454
+"Kaivoksela, Vantaa",60.267664,24.868711
+"Radiokatu 5, Helsinki",60.203522,24.92266
+"Otaniementie, Espoo",60.18015,24.834483
+"Entressen kirjasto, Espoo",60.203539,24.658776
+"Kilonrinne 10, Espoo",60.221592,24.779564
+"Maapadontie 5, Helsinki",60.231445,24.946774
+"Helsingin päärautatieasema, Helsinki",60.171457,24.941498
+"Jakomäentie 6, Helsinki",60.25827,25.073552
+"Tennistie 1, Vantaa",60.301763,25.05416
+"Karstulantie 8, Helsinki",60.198644,24.953226
+"Hämeentie 153, Helsinki",60.211553,24.979135
+"Helsinki-Vantaa lentoasema T2, Vantaa",60.318036,24.966701
+"Tyynenmerenkatu 8, Helsinki",60.153961,24.921032
+"Helsinki-Vantaa Airport, Vantaa",60.318933,24.968296
+"Järvenperä, Espoo",60.245292,24.714392
+"Orionintie 1, Espoo",60.17765,24.777149
+"Jätkäsaari, Helsinki",60.15452,24.91065
+"Olarin koulu ja lukio, Espoo",60.180365,24.737449
+"Hyljeluodontie 3, Espoo",60.156297,24.711331
+"Avaruuskatu 3, Espoo",60.169497,24.726745
+"Kansaneläkelaitos, Helsinki",60.188657,24.919179
+"Hakaniemenranta 12, Helsinki",60.179008,24.95892
+"Arabianranta, Helsinki",60.208009,24.978009
+"Eteläinen Rautatiekatu 4, Helsinki",60.170456,24.932825
+"Mankkaa, Espoo",60.191912,24.767707
+"Otakaari 4, Espoo",60.187193,24.826872
+"Teollisuuskatu 21, Helsinki",60.19422,24.948811
+"Rautatientorin metroasema, Helsinki",60.170915,24.941264
+"Tuomarilan asema, Espoo",60.206213,24.682329
+"Munkkiniemen aukio, 1388, Helsinki",60.19598,24.886184
+"Lapinmäentie 1, Helsinki",60.207365,24.881944
+"Helsinginkatu 26, Helsinki",60.186124,24.949226
+"Käenkuja 1, Helsinki",60.185795,24.962214
+"Hki linja-autoasema, Helsinki",60.169621,24.932544
+"Helsingin päärautatieasema, Helsinki",60.171457,24.941498
+"Toinen Linja 4, Helsinki",60.181453,24.946849
+"Latokartanontie, Helsinki",60.246018,25.011988
+"Karakaari 7, Espoo",60.222416,24.755908
+"Kaustisenpolku 1, Helsinki",60.23885,24.881349
+"Karhunkierros 1, Kirkkonummi",60.129092,24.473032
+"Finlandia-talo, Helsinki",60.175472,24.933781
+"WeeGee-talo, Espoo",60.178172,24.798774
+"Kitarakuja 1, Helsinki",60.238126,24.877079
+"Hattulantie 1, Helsinki",60.195445,24.956619
+"Kutomotie 1, Helsinki",60.215404,24.873313
+"Talontie 1, Helsinki",60.209401,24.890577
+"Suurpelto, Espoo",60.18669,24.7421
+"Jämeräntaival 1, Espoo",60.186836,24.834706
+"Itsehallintotie 1, Espoo",60.210787,24.821268
+"Siltavuorenpenger 5, Helsinki",60.175191,24.953034
+"Antti Korpin Tie 4, Helsinki",60.21914,24.965416
+"Tukholmankatu 1, Helsinki",60.191547,24.911133
+"Kaarikuja, 4425, Helsinki",60.238006,25.078526
+"SAVIO, Kerava",60.381284,25.097796
+"Helsinginkatu 24, Helsinki",60.186204,24.950339
+"Viikinkaari 1, Helsinki",60.225585,25.017364
+"Keilaranta 17, Espoo",60.178804,24.836263
+"Lommila, Espoo",60.217545,24.655933
+"Muusantori 1, Helsinki",60.207487,24.855796
+"Juustenintie 3, Helsinki",60.24499,24.868757
+"Kuninkaantien lukio, Espoo",60.210127,24.660041
+"Mannerheimintie 46, Helsinki",60.179096,24.927594
+"Westendinasema, Espoo",60.168685,24.804153
+"Munkkiniemen Puistotie 1, Helsinki",60.196968,24.884213
+"Pohjolankatu 38, Helsinki",60.216916,24.953405
+"Mäkkylä, Espoo",60.220526,24.832968
+"Espoonlahden uimahalli, Espoo",60.146462,24.659301
+"Westendin asema, Espoo",60.168915,24.804625
+"Malmin sairaala, Helsinki",60.253518,24.998846
+"Paavalin kirkko, Helsinki",60.198523,24.961821
+"Tapanilan asema, Helsinki",60.263475,25.029481
+"Ilkantie 4, Helsinki",60.221731,24.90116
+"Ida Aalbergin Tie 1, Helsinki",60.231018,24.899988
+"Jokiniementie 31, Vantaa",60.283907,25.074708
+"Salmisaari, Helsinki",60.163181,24.905759
+"Porthania, Helsinki",60.170075,24.948912
+"Kauppakorkeakoulut, Helsinki",60.171302,24.924927
+"Niittykumpu, Espoo",60.170365,24.763017
+"Kauppakeskus Kaari, Helsinki",60.237001,24.89205
+"Kulosaari, Helsinki",60.188761,25.007139
+"Vantaanportti, V5160, Vantaa",60.293782,24.959314
+"Lakelankatu 1, Espoo",60.208561,24.657494
+"Välimerenkatu 5, Helsinki",60.160268,24.918868
+"Metsänpojankuja 1, Espoo",60.186464,24.807207
+"Tikkurilan lukio, Vantaa",60.298973,25.050028
+"Itäkeskuksen metroasema, Helsinki",60.209868,25.077349
+"Rälssintie 16, Helsinki",60.241488,24.989106
+"Mannerheimintie 50, Helsinki",60.179917,24.927217
+"Avaruuskatu 1, Espoo",60.169233,24.726025
+"Aleksis Kiven katu, Helsinki",60.193112,24.94363
+"Siltavuorenpenger 1, Helsinki",60.175875,24.954391
+"Metsänpojankuja 3, Espoo",60.186017,24.805703
+"Postintaival 7, Helsinki",60.212913,24.918366
+"Tasetie 8, Vantaa",60.29079,24.969088
+"Areenankuja 1, Helsinki",60.205699,24.929182
+"Klaneettitie 1, Helsinki",60.237363,24.878194
+"Kumpula, Helsinki",60.20872,24.951218
+"Jan-Magnus Janssonin Aukio 1, Helsinki",60.201471,24.96532
+"Käpyläntie 1, Helsinki",60.214233,24.960576
+"Ruosilantie 1, Helsinki",60.236874,24.859511
+"Runeberginkatu 14, Helsinki",60.171805,24.923245
+"Takomotie 1, Helsinki",60.216984,24.876735
+"Bulevardi 31, Helsinki",60.163292,24.93187
+"REKOLA, Vantaa",60.330468,25.066532
+"Italian suurlähetystö (Embassy ofItaly), Helsinki",60.158985,24.957349
+"ILMALA, Helsinki",60.208219,24.920213
+"Isonnevantie 16, Helsinki",60.214539,24.891137
+"Kallion kirkko, Helsinki",60.184276,24.949341
+"Ratapihantie 9, Helsinki",60.200173,24.934817
+"Sonera-stadium, Helsinki",60.187639,24.922447
+"Kettutie 8, Helsinki",60.207015,25.037596
+"Otakaari 5, Espoo",60.186102,24.828315
+"Akanapolku 2, Vantaa",60.299018,25.061146
+"Valimotie 1, Helsinki",60.215376,24.876582
+"Vaskivuoren lukio, Vantaa",60.266414,24.85136
+"Helsinginkatu 25, Helsinki",60.18681,24.94765
+"Pihlajamäki, Helsinki",60.237169,25.013635
+"Latokaski, Espoo",60.177907,24.658062
+"Auroran sairaala, Helsinki",60.191484,24.925401
+"Aleksanterinkatu 1, Helsinki",60.169474,24.95807
+"Kuusitie, Helsinki",60.195059,24.902294
+"Saunalahti, Espoo",60.163127,24.620125
+"LOUHELA, Vantaa",60.27038,24.854451
+"Lääkärinkatu 8, Helsinki",60.191726,24.91794
+"Karstulantie 6, Helsinki",60.197952,24.953756
+"Alvar Aallon kuja 2, Helsinki",60.172672,24.937342
+"Helsingin päärautatieasema, Helsinki",60.171457,24.941498
+"Töölönkatu, Helsinki",60.185196,24.9181
+"Vuolukiventie, Helsinki",60.237095,25.002669
+"Itämerenkatu 21, Helsinki",60.163534,24.909541
+"Merihaka, Helsinki",60.178882,24.960086
+"Keilalahdentie 2, Espoo",60.171278,24.828068
+"Pukinmäen asema, Helsinki",60.242688,24.99411
+"Prinsessantie 2, Helsinki",60.207026,25.059107
+"Töölön sairaala, Helsinki",60.18128,24.922509
+"Unioninkatu 40, Helsinki",60.172672,24.949398
+"Kevätkatu 2, Helsinki",60.227835,25.029724
+"Biomedicum, Helsinki",60.190556,24.905696
+"Lehtimäki, Espoo",60.320142,24.506465
+"Mäkelänrinteen lukio, Helsinki",60.198768,24.949145
+"Kirkkonummen asema, Kirkkonummi",60.119603,24.439015
+"Huokotie 5, Helsinki",60.260844,25.080739
+"Gesterby, Kirkkonummi",60.133031,24.443472
+"Mannerheimintie 164, Helsinki",60.199752,24.898883
+"Viherlaakso, Espoo",60.231254,24.746933
+"Tenholantie 10, Helsinki",60.202303,24.908013
+"Haartmaninkatu 8, Helsinki",60.190512,24.905859
+"Tähkäkuja 5, Vantaa",60.299626,25.062775
+"Arentikuja 1, Helsinki",60.244597,24.853858
+"Töölön tulli, Helsinki",60.191916,24.911183
+"Kalajärvi, Espoo",60.304545,24.731656
+"Raumantie 1, Helsinki",60.2057,24.878688
+"Espoon asema, Espoo",60.205123,24.65632
+"Senaatintori, Helsinki",60.169057,24.95143
+"Pitäjänmäen asema, Helsinki",60.2232,24.860483
+"Nordenskiöldinkatu 1, Helsinki",60.186226,24.91773
+"Keran asema, Espoo",60.216077,24.753627
+"Kutojantie 2, Espoo",60.210106,24.751443
+"Viikinkaari 11, Helsinki",60.227521,25.012895
+"Töölöntullinkatu 6, Helsinki",60.189922,24.913437
+"Aapelinkatu 5, Espoo",60.156444,24.750353
+"Leppävaaran stadion, Espoo",60.225827,24.799135
+"Santahamina, Helsinki",60.145626,25.044337
+"Karhupuisto, Helsinki",60.18376,24.952316
+"Valimo, Helsinki",60.222188,24.875921
+"Tilkka, Helsinki",60.198351,24.901223
+"Lippajärvi, Espoo",60.229725,24.725685
+"Porvoonkatu 1, Helsinki",60.188758,24.952272
+"Karakallio, Espoo",60.23254,24.760824
+"Suomenlinna, Helsinki",60.146465,24.992567
+"Forum, Helsinki",60.169294,24.938014
+"Näätätie, Helsinki",60.20535,25.040031
+"Naistenklinikka, Helsinki",60.188941,24.911004
+"Vuosaaren terveysasema, Helsinki",60.206356,25.146569
+"Vanha Maantie 9, Espoo",60.223441,24.80535
+"Valimotie 8, Helsinki",60.217847,24.877776
+"Linnoituksentie 10, Helsinki",60.241993,25.070913
+"Rantaharju 10, Espoo",60.153761,24.75632
+"Energiakatu 3, Helsinki",60.165879,24.903859
+"Vantaankosken liityntäpysäköinti, Vantaa",60.285314,24.84734
+"Pitäjänmäen aseman liityntäpysäköinti, Helsinki",60.222936,24.856833
+"Sibeliuksenkatu 14, Helsinki",60.179966,24.919442
+"Kulttuuritalo, Helsinki",60.188292,24.944199
+"Olari, Espoo",60.176411,24.742409
+"Musiikkitalo, Helsinki",60.173681,24.934981
+"Väinö Auerin Katu 1, Helsinki",60.209224,24.96659
+"Tyynenmerenkatu 11, Helsinki",60.156221,24.920853
+"Vanhakirkko, Helsinki",60.166404,24.939295
+"Ida Aalbergin Tie 1, Helsinki",60.23059,24.900178
+"Kampin metroasema, Helsinki",60.16898,24.931733
+"Piispansilta, Espoo",60.160398,24.73769
+"Hanko-Hyvinkää, Vihti",60.323304,24.307178
+"Sörnäisten metroasema, Helsinki",60.187866,24.960693
+"Heikintori, Espoo",60.176114,24.800262
+"Jakomäki, Helsinki",60.257424,25.076958
+"Arcada, Helsinki",60.201413,24.965201
+"Viikin tiedepuisto, Helsinki",60.225797,25.017091
+"Söderkulla, Sipoo",60.299847,25.306954
+"Peijaksen sairaala, Vantaa",60.331376,25.059268
+"Peijaksen Hospital Heliport, Vantaa",60.331112,25.060833
+"Peltokyläntie 3, Helsinki",60.267414,24.984658
+"Kätilöopisto, 3055, Helsinki",60.204019,24.950394
+"Käpylän asema, Helsinki",60.220267,24.947152
+"Fabianinkatu 33, Helsinki",60.169486,24.950119
+"Innopoli, Espoo",60.186064,24.812986
+"Vanha Viertotie 23, Helsinki",60.211869,24.88309
+"IKEA Vantaa, Vantaa",60.276399,25.084176
+"Pasilanraitio 11, Helsinki",60.200864,24.926167
+"Sturenkatu 4, Helsinki",60.188337,24.944236
+"Vuosaaren metroasema, Helsinki",60.207617,25.142493
+"Messuaukio 1, Helsinki",60.203431,24.935839
+"Helsingin päärautatieasema, Helsinki",60.171457,24.941498
+"Iivisniemi, Espoo",60.148596,24.69431
+"Alppikatu 2, Helsinki",60.185629,24.940456
+"Oulunkylän asema, Helsinki",60.228269,24.966567
+"Tennispalatsi, Helsinki",60.169581,24.930462
+"Munkkivuori, Helsinki",60.210985,24.865462
+"Hattulantie 2, Helsinki",60.196641,24.956129
+"Alvar Aallon puisto, E2226, Espoo",60.183737,24.829047
+"Tallberginkatu 1, Helsinki",60.161732,24.904033
+"Katajanokan terminaali, Helsinki",60.16426,24.969331
+"Huopalahden asema, Helsinki",60.218459,24.893446
+"Barona Areena, Espoo",60.177765,24.785952
+"Koivukylän asema, Vantaa",60.323625,25.060133
+"KÄPYLÄ, Helsinki",60.219508,24.944582
+"Hiekkaharju, Vantaa",60.303275,25.048799
+"Mikkola, Vantaa",60.341407,25.096952
+"Sturenkatu 2, Helsinki",60.18754,24.943204
+"Teekkarikylä, Espoo",60.188428,24.834419
+"Makasiiniterminaali, Helsinki",60.163914,24.954801
+"Kauppakeskus Itis, Helsinki",60.212257,25.083007
+"Kirkkokatu 16, Espoo",60.213017,24.6525
+"Lintukorventie 2, Espoo",60.236862,24.820674
+"Munkkiniemi, Helsinki",60.201698,24.863703
+"Veikkola, Kirkkonummi",60.280541,24.416511
+"Rastila, Helsinki",60.205567,25.120158
+"Haartmaninkatu 1, Helsinki",60.189687,24.911053
+"Seidensticker Areena - Malmin jäähalli, Helsinki",60.243036,25.021818
+"Meilahti, Helsinki",60.190508,24.890286
+"Katajanokka, Helsinki",60.165875,24.971324
+"POHJOIS-HAAGA, Helsinki",60.23125,24.883368
+"Puistolan asema, Helsinki",60.275264,25.036086
+"Lähderanta, Espoo",60.245039,24.739249
+"Läntinen Brahenkatu 2, Helsinki",60.18685,24.948158
+"Töölön kisahalli, 1913, Helsinki",60.184299,24.923722
+"Puustellinmäki, Espoo",60.221984,24.822675
+"Hakaniemen Torikatu 2, Helsinki",60.180321,24.952636
+"Nikkilä, Sipoo",60.382322,25.26797
+"Nihtisilta, Espoo",60.210679,24.744247
+"Meilahdentie 2, Helsinki",60.191443,24.895482
+"Lehtimäentie 1, Espoo",60.212804,24.654664
+"Kaupinkalliontie 3, Espoo",60.178801,24.801659
+"Kuusitie 5, Helsinki",60.195071,24.899363
+"Myyrmanni, Vantaa",60.260296,24.853445
+"Mistelitie 26, Vantaa",60.313517,25.00253
+"Konemiehentie 2, Espoo",60.186985,24.821349
+"Puotila, Helsinki",60.214491,25.093737
+"Lauttasaari, Helsinki",60.159463,24.878706
+"Sofianlehdonkatu 5, Helsinki",60.204037,24.951158
+"Mannerheimintie 1, Helsinki",60.168616,24.942134
+"Ruskeasuo, Helsinki",60.203286,24.898284
+"Hakunila, Vantaa",60.269971,25.107692
+"Matinkylä, Espoo",60.15968,24.739126
+"Kauppatori, Helsinki",60.167418,24.951658
+"Kiasma, Helsinki",60.171989,24.936688
+"Kurvitar, Helsinki",60.188529,24.963339
+"Vanha Maantie 6, Espoo",60.221101,24.805074
+"Stockmann Itis, Helsinki",60.213148,25.08505
+"Martinlaakson asema, Vantaa",60.27804,24.852523
+"Soukka, Espoo",60.137662,24.666527
+"Pajuniityntie 11, Helsinki",60.218156,24.906372
+"Kalasataman metroasema, Helsinki",60.187622,24.978079
+"Itis shopping centre, Helsinki",60.212257,25.083007
+"Leiritie 1, Vantaa",60.257963,24.844451
+"Tivolikuja 1, Helsinki",60.188658,24.940573
+"Flamingo, Vantaa",60.291071,24.969283
+"TAPANILA, Helsinki",60.264403,25.030677
+"Olympiaterminaali, Helsinki",60.160518,24.95778
+"Kamppi, kaukoliikenne, Helsinki",60.169586,24.933375
+"Töölöntori, Helsinki",60.179679,24.923767
+"Otakaari 1, Espoo",60.186102,24.828315
+"Kaivokatu 1, Helsinki",60.171198,24.941828
+"Helsingin päärautatieasema, Helsinki",60.171457,24.941498
+"Maunula, Helsinki",60.231619,24.928165
+"Myyrmäen asema, Vantaa",60.261859,24.854866
+"Ruusutorpantie 4, Espoo",60.214747,24.804325
+"Albertinkatu 32, Helsinki",60.163486,24.933371
+"Arabiankatu, Helsinki",60.206915,24.974559
+"OULUNKYLÄ, Helsinki",60.228796,24.967558
+"Herttoniemen metroasema, Helsinki",60.195005,25.030852
+"Kivenlahti, Espoo",60.153788,24.6361
+"TUOMARILA, Espoo",60.205879,24.681692
+"Station Rautatientori, Helsinki",60.17125,24.944118
+"Jorvi, Espoo",60.22264,24.685012
+"Gustaf Hällströmin Katu 2, Helsinki",60.204867,24.963034
+"Espoo",60.205145,24.656968
+"Myllypuro, Helsinki",60.224584,25.076456
+"Ooppera, Helsinki",60.182005,24.927889
+"Haartmaninkatu 4, Helsinki",60.189367,24.909017
+"Lippulaiva, Espoo",60.149004,24.655872
+"MASALA, Kirkkonummi",60.15858,24.538561
+"Mannerheimintie 172, Helsinki",60.206733,24.897282
+"PITÄJÄNMÄKI, Helsinki",60.223603,24.860037
+"Keravan asema, Kerava",60.404394,25.105978
+"Malminkartano, Helsinki",60.249431,24.861226
+"Airport, Vantaa",60.316357,24.969138
+"Töölön Kisahalli, Helsinki",60.183349,24.926035
+"Dipoli, Espoo",60.185031,24.832627
+"Pitäjänmäen aseman liityntäpysäköinti, Helsinki",60.222936,24.856833
+"KAUKLAHTI, Espoo",60.189425,24.599725
+"Kaniini, Helsinki",60.172612,24.947856
+"Kannelmäki, Helsinki",60.239722,24.876612
+"Tukholmankatu 10, Helsinki",60.191107,24.902034
+"Katajanokanlaituri 6, Helsinki",60.165302,24.963664
+"Länsiterminaali, Helsinki",60.155474,24.922088
+"Martinlaakso, Vantaa",60.277263,24.853243
+"PUKINMÄKI, Helsinki",60.240899,24.990013
+"Kaapelitehdas, Helsinki",60.161746,24.904009
+"KILO, Espoo",60.217991,24.780817
+"Puistola, Helsinki",60.275223,25.035506
+"Viikki, Helsinki",60.221823,25.023861
+"Leppävaaran asema, Espoo",60.219424,24.814576
+"Keskuskatu 2, Helsinki",60.168616,24.942134
+"Steissi, Helsinki",60.171457,24.941498
+"Linnankatu 9, Helsinki",60.165759,24.969998
+"KAUNIAINEN, Kauniainen",60.211753,24.730537
+"Malmin asema, Helsinki",60.250609,25.012427
+"Kontula, Helsinki",60.236413,25.082534
+"KOIVUKYLÄ, Vantaa",60.323271,25.059355
+"Kumpulan kampus, Helsinki",60.205156,24.962808
+"Hartwall Arena, Helsinki",60.205665,24.929171
+"Länsisatama, Helsinki",60.156043,24.92234
+"Helsinki-Vantaan lentoasema, Vantaa",60.318933,24.968296
+"Messukeskus, Helsinki",60.201256,24.937121
+"Kaisaniemen metroasema, Helsinki",60.171135,24.948261
+"Kamppi, kaukoliikenne, Helsinki",60.169586,24.933375
+"Otaniemi, Espoo",60.187938,24.832845
+"Vuosaari, Helsinki",60.207129,25.144063
+"Mellunmäki, Helsinki",60.238248,25.109276
+"Lentokentän Tekninen alue, Vantaa",60.310958,24.959808
+"Kirkkonummi",60.11974,24.440888
+"Kerava",60.404455,25.105055
+"Ruoholahti, Helsinki",60.162706,24.913831
+"Tapiola, Espoo",60.176531,24.80634
+"Herttoniemi, Helsinki",60.194992,25.031411
+"Jumbo, Vantaa",60.292226,24.964162
+"Myyrmäki, Vantaa",60.261243,24.855681
+"Helsingin rautatieasema, Helsinki",60.171831,24.9412
+"Korso, Vantaa",60.351183,25.077784
+"Tikkurilan asema, Vantaa",60.292327,25.044112
+"Malmi, Helsinki",60.251283,25.011215
+"Iso Omena, Espoo",60.161624,24.737926
+"Hakaniemen metroasema, Helsinki",60.179578,24.951153
+"Lentoasema, Vantaa",60.315781,24.968452
+"Tikkurila, Vantaa",60.291482,25.043217
+"Itäkeskus, Helsinki",60.209978,25.0771
+"Elielinaukio, Helsinki",60.171808,24.939488
+"Pasila, Helsinki",60.199017,24.933973
+"Pasilan asema, Helsinki",60.199228,24.933114
+"Sörnäinen, Helsinki",60.187414,24.959895
+"Espoon keskus, Espoo",60.205016,24.657941
+"Rautatientori, Helsinki",60.171283,24.942572
+"Rautatieasema, Helsinki",60.170337,24.941295
+"Leppävaara, Espoo",60.219235,24.81329
+"Helsinki",60.172992,24.942044
+"Kamppi, Helsinki",60.16902,24.931702
+"Isonvillasaarentie 1, Helsinki",60.220968,25.145916
+"Pengerkatu 21, Helsinki",60.185816,24.95959
+"Tehtaankatu 25, Helsinki",60.158061,24.935694
+"Pihkatie 5, Helsinki",60.251844,24.854865
+"Ruotsinpiha 2, Vantaa",60.286101,24.958561
+"Pengerkatu 22, Helsinki",60.187023,24.959144
+"Porvoonkatu 25, Helsinki",60.191526,24.944235
+"Katontekijänkuja 1, Helsinki",60.252831,25.022475
+"Itsehallintokuja 6, Espoo",60.209667,24.82636
+"Jönsaksentie 6, Vantaa",60.261808,24.855063
+"Hämeentie 95, Helsinki",60.197236,24.962713
+"Sörnäistenkatu 1, Helsinki",60.189446,24.969527
+"Hämeentie 28, Helsinki",60.183331,24.957985
+"Huopalahdentie 3, Helsinki",60.197527,24.884953
+"Hämeentie, Helsinki",60.198494,24.961933
+"Klippinkitie 1, Espoo",60.191724,24.597627
+"Mäntytie 1, Helsinki",60.191634,24.901802
+"Pitäjänmäentie 13, Helsinki",60.224203,24.861891
+"Taimistontie 2, Helsinki",60.218032,24.866878
+"Karakalliontie 14, Espoo",60.230409,24.765385
+"Scandic Park Helsinki, Helsinki",60.178945,24.92796
+"Teknikontie 7, Vantaa",60.310904,24.958244
+"Sellosali, Espoo",60.217642,24.808221
+"Ilmalantori 1, Helsinki",60.206948,24.916597
+"Pähkinätie 3, Vantaa",60.265007,24.803471
+"Roihuvuorentie 30, Helsinki",60.202921,25.059061
+"Huopalahdentie 24, Helsinki",60.208107,24.878713
+"Vaakatie 1, Vantaa",60.253199,24.820022
+"Niittykummuntie 6, Espoo",60.16898,24.757572
+"Samis, Ka1708, Kauniainen",60.21386,24.720831
+"Kuunkehrä, Espoo",60.173181,24.725779
+"Lauttasaarentie 32, Helsinki",60.160171,24.879893
+"Hitsaajankatu 9, Helsinki",60.192341,25.029237
+"Alakiventie 1, Helsinki",60.222771,25.075726
+"Perhonkatu 1, Helsinki",60.170014,24.925228
+"Koskelantie 23, Helsinki",60.211301,24.954459
+"Riiantie 1, Espoo",60.187539,24.592701
+"Maasälväntie 16, Helsinki",60.238611,25.012169
+"Itäviitta 1, Espoo",60.166308,24.614824
+"Koudantie 2, Helsinki",60.267222,25.056103
+"Herttoniemi(M), 4040, Helsinki",60.195048,25.030868
+"Neljäs Linja 26, Helsinki",60.184345,24.946849
+"Riistavuorenkuja 8, Helsinki",60.21942,24.885745
+"Pietarinkatu 1, Helsinki",60.158398,24.952162
+"Pyhtäänkorventie 21, Vantaa",60.300572,24.975051
+"Vaasankatu 9, Helsinki",60.188467,24.959
+"Mattilan päiväkoti, Tuusula",60.412161,25.071417
+"Brinkinmäentie 1, Espoo",60.169549,24.615761
+"Rosendalinrinki 1, Vantaa",60.268747,24.967815
+"Kaisaniemenkatu 3, Helsinki",60.171128,24.947133
+"Kivikko, Helsinki",60.242773,25.064958
+"Sammalkalliontie 6, Espoo",60.176184,24.734812
+"Kuortaneenkatu 7, Helsinki",60.196333,24.944331
+"Opettajantie 3, Espoo",60.144638,24.664583
+"Pohjois-Tapiolan koulu ja lukio, Espoo",60.187195,24.790872
+"Sibelius-lukio, Helsinki",60.174539,24.956314
+"Espoontie 25, Espoo",60.219861,24.664632
+"Stoa, Helsinki",60.211934,25.07918
+"Hietaniemenkatu 1, Helsinki",60.169971,24.925879
+"Hämeentie 26, Helsinki",60.18311,24.957043
+"Säterinkatu 8, Vantaa",60.269018,24.962406
+"Kaisaniemenkatu, Helsinki",60.171765,24.947675
+"Näyttelijäntie, Helsinki",60.227882,24.894615
+"Hirsipadontie 5, Helsinki",60.23409,24.95172
+"Katajanokanlaituri 1, Helsinki",60.167899,24.958492
+"Taavetti Laitisen Katu 1, Helsinki",60.19879,24.897122
+"Kaarlenkatu 15, Helsinki",60.186725,24.952057
+"Unioninkatu 39, Helsinki",60.174338,24.950827
+"Vanha Yrttimaantie 22, Helsinki",60.268709,25.013417
+"Reiherintie 7, Helsinki",60.169248,25.042535
+"Karapellontie 11, Espoo",60.217195,24.75103
+"Helsingin Kaupunginteatteri, Helsinki",60.181805,24.94262
+"Sturenkatu 26, Helsinki",60.194147,24.955761
+"Alppila, Helsinki",60.189893,24.942922
+"Tenholantie 1, Helsinki",60.20279,24.901883
+"Mustialankatu 1, Helsinki",60.230028,25.02199
+"Yrjönkatu 21, Helsinki",60.168053,24.939034
+"Vallilan varikko, Helsinki",60.196701,24.962475
+"Tammistonkatu 27, Vantaa",60.273324,24.96348
+"Talonpojantie 25, Helsinki",60.226906,25.023424
+"Takkatie 7, Helsinki",60.222942,24.854811
+"Talvelantie 4, Helsinki",60.253896,25.001266
+"Vaijeritie 1, Vantaa",60.254885,24.808975
+"Kirjurinkuja 1, Espoo",60.215942,24.826179
+"Töölönkatu 27, Helsinki",60.180343,24.925153
+"Heikinlaaksontie, Helsinki",60.269854,25.069296
+"Kutomotie 6, Helsinki",60.213822,24.874372
+"Malminkartanontie 1, Helsinki",60.244,24.847519
+"Veromäen koulu, Vantaa",60.286159,24.962077
+"Apollonkatu, Helsinki",60.176424,24.922296
+"Mestarintie 5, Vantaa",60.30532,24.851848
+"Arinatie 20, Vantaa",60.282928,24.965976
+"Kutomotie 12, Helsinki",60.214763,24.87039
+"Vieraskuja, Espoo",60.207492,24.661783
+"Hagelstamintie 20, Vantaa",60.281697,24.960717
+"Hirsalantie 11, Kirkkonummi",60.130741,24.514072
+"Vanamonkuja 1, Vantaa",60.308121,25.026664
+"Käpyläntie 4, Helsinki",60.214439,24.958216
+"Vattuniemenkatu 16, Helsinki",60.152686,24.884151
+"Backåkersvägen 19, Helsingfors",60.220744,24.898406
+"Fredrikinkatu 48, Helsinki",60.169401,24.929106
+"Makasiiniterminaali, Helsinki",60.163914,24.954801
+"Bulevardi 40, Helsinki",60.162548,24.932583
+"Hämeentie 36, Helsinki",60.184479,24.959573
+"Linnoitustie 6, Espoo",60.210938,24.814092
+"Hämeentie 70, Helsinki",60.191015,24.964055
+"Mannerheimintie 47, Helsinki",60.188811,24.918179
+"Kirstintie 17, Espoo",60.204256,24.673195
+"Mannerheimintie, Helsinki",60.187618,24.919099
+"Karjalankatu 2, Helsinki",60.193159,24.936611
+"Huopalahdentie 1, Helsinki",60.196779,24.885921
+"Metsänhoitajankatu, Helsinki",60.233496,25.04357
+"Koivu-Mankkaan tie 5, Espoo",60.176666,24.782595
+"Kansallisteatteri, Helsinki",60.172401,24.943819
+"Kluuvikatu 1, Helsinki",60.168337,24.947884
+"Pasilanraitio 12, Helsinki",60.200973,24.925095
+"Nuolikuja 6, Vantaa",60.298639,24.911123
+"Vattuniemenranta 2, Helsinki",60.154289,24.886741
+"Niittymaantie 1, Espoo",60.170088,24.775308
+"Otaranta 6, Espoo",60.184296,24.834837
+"Katariina Saksilaisen katu, Helsinki",60.216688,24.984894
+"Mechelininkatu 15, Helsinki",60.172398,24.9203
+"Kurkisuontie 12, Helsinki",60.233038,25.072089
+"Siltasaarenkatu 15, Helsinki",60.182505,24.949831
+"Osmontie 34, Helsinki",60.219114,24.946263
+"Kaivosrinteenkuja 2, Vantaa",60.270214,24.872251
+"Porslahdentie, Helsinki",60.222172,25.149255
+"Kaskenkaatajantie 1, Espoo",60.181941,24.793892
+"Pohjantori, E2051, Espoo",60.1836,24.79511
+"Sotungintie 19, Vantaa",60.2802,25.12162
+"Korppaanmäentie 17, Helsinki",60.205582,24.892735
+"Siltavoudintie 1, Helsinki",60.22925,24.965241
+"Töyrytie 6, Helsinki",60.226163,24.924839
+"Simonkallion koulu, Vantaa",60.307161,25.024024
+"Toinen Linja 10, Helsinki",60.183461,24.942557
+"Maununnevantie 1, Helsinki",60.24392,24.900228
+"Valimotie 16, Helsinki",60.22012,24.876709
+"Pursimiehenkatu 25, Helsinki",60.15892,24.936055
+"Otavantie 1, Helsinki",60.156649,24.879273
+"Untamontie 10, Helsinki",60.213164,24.952971
+"Myyrmäentie 2, Vantaa",60.264619,24.852782
+"Horsmakuja 4, Helsinki",60.202791,25.082201
+"Vyökatu 1, Helsinki",60.166666,24.969401
+"Pallomylly, Helsinki",60.21935,25.079587
+"Emma - Espoon modernin taiteen museo, Espoo",60.178754,24.794426
+"Wallininkuja 3, Helsinki",60.184958,24.945241
+"Peshawar, Espoo",60.209874,24.754144
+"Helsinginkatu 14, Helsinki",60.186885,24.954301
+"Jämeräntaival 3, Espoo",60.187339,24.836368
+"Kuurinniitty, Espoo",60.197777,24.700396
+"Urheilupuistontie 2, Espoo",60.178776,24.787253
+"Munkkiniemen Puistotie 25, Helsinki",60.199215,24.873639
+"Nuijavuori 1, Espoo",60.211466,24.767072
+"Pikku Satamakatu 3, Helsinki",60.165633,24.967645
+"Kuusitie 11, Helsinki",60.19473,24.897707
+"Käskynhaltijantie 14, Helsinki",60.23608,24.973668
+"Pasilan kirjasto, Helsinki",60.200775,24.935879
+"Tanhuantie 1, Helsinki",60.236131,25.094106
+"Kamreerintie 2, Espoo",60.203513,24.653955
+"Läkkisepänkuja 8, Helsinki",60.220523,24.937527
+"Malmin Kauppatie 8, Helsinki",60.249799,25.006576
+"Linnatullinkatu 1, Espoo",60.218871,24.80822
+"Hagelstamintie 27, Vantaa",60.280155,24.968482
+"Aalto 6, Espoo",60.149527,24.639391
+"Vantaanpuisto, Vantaa",60.300195,24.85388
+"Vuorikatu 14, Helsinki",60.171654,24.946883
+"Arabiankatu 12, Helsinki",60.209273,24.978625
+"Sampsantie 50, Helsinki",60.217311,24.94587
+"Haapaniemenkatu 12, Helsinki",60.180017,24.960913
+"Urheilukatu 9, Helsinki",60.190308,24.918535
+"Kiltakuja 1, Espoo",60.199661,24.654609
+"Vääksyntie 4, Helsinki",60.190834,24.961054
+"Keijumäki 1, Espoo",60.18872,24.799679
+"Pukinkuja 2, Helsinki",60.250655,24.982978
+"Haapaniemenkatu 11, Helsinki",60.179039,24.959784
+"Runeberginkatu 32, Helsinki",60.176157,24.921739
+"Ylistörmä 5, Espoo",60.176077,24.738065
+"Startup Sauna, Espoo",60.180562,24.832284
+"Tukholmankatu 2, Helsinki",60.190748,24.911725
+"Asema-aukio 2, Helsinki",60.170488,24.938321
+"Arabiankatu 6, Helsinki",60.207493,24.977294
+"Länsisatamankatu 16, Helsinki",60.159373,24.909932
+"Talttakuja 1, Helsinki",60.242117,25.025
+"Paciuksenkatu 29, Helsinki",60.195544,24.890673
+"Mäkitorpantie 30, Helsinki",60.226648,24.954857
+"Untamontie 15, Helsinki",60.212688,24.955329
+"Läntinen Papinkatu, Helsinki",60.184604,24.948679
+"Tapiolan terveysasema, Espoo",60.178288,24.798093
+"Ensi Linja 2, Helsinki",60.181851,24.942424
+"Isonnevantie 28, Helsinki",60.217104,24.886923
+"Juvanpuro 1, Espoo",60.277818,24.752095
+"Soukantie 16, Espoo",60.141712,24.66978
+"Teknillinen korkeakoulu, Espoo",60.187185,24.827666
+"Snellmaninkatu 1, Helsinki",60.169808,24.954714
+"Liuskekuja 1, Helsinki",60.236222,25.018744
+"Allergia-apu, Helsinki",60.195835,24.960099
+"Isokaari 9, Helsinki",60.157183,24.868355
+"Krakankuja 2, Vantaa",60.288622,24.944979
+"Käskynhaltijantie 11, Helsinki",60.234658,24.959993
+"Eteläinen Rautatiekatu, Helsinki",60.170228,24.93002
+"Hansakallio 2, Espoo",60.188713,24.594058
+"Piilipuuntie 7, Espoo",60.185961,24.739838
+"Kaskilaaksontie 1, Espoo",60.139443,24.660845
+"Vilppulantie 1, Helsinki",60.248396,25.011233
+"Kivikonkaari 49, Helsinki",60.232117,25.057027
+"Tietotie 6, Espoo",60.183853,24.819338
+"Kaupintie 11, Helsinki",60.231135,24.881342
+"Kala-Maija 3, Espoo",60.15937,24.740169
+"Mannerheimintie 81, Helsinki",60.19319,24.908774
+"Merenkulkijankatu 1, Espoo",60.147446,24.656727
+"Annankatu 18, Helsinki",60.165513,24.937804
+"Postipuuntie 10, Espoo",60.22238,24.823297
+"Alppikatu 9, Helsinki",60.185297,24.943398
+"Nelikkokuja 1, Espoo",60.161654,24.7414
+"Vanha Nurmijärventie, Vantaa",60.28056,24.875099
+"Kaikukatu 2, Helsinki",60.183027,24.95923
+"Vesikuja 8, Helsinki",60.196408,24.893631
+"Maapallonkatu 8, Espoo",60.170968,24.726085
+"Länsisatamankatu 23, Helsinki",60.158222,24.910419
+"Pikku Huopalahti, Helsinki",60.204534,24.889584
+"Linnoitustie 9, Espoo",60.212193,24.811229
+"Käskynhaltijantie, Helsinki",60.237628,24.975655
+"Hämeentie 44, Helsinki",60.185914,24.960602
+"Pohjantie 2, Espoo",60.175006,24.798162
+"Juustenintie 1, Helsinki",60.244758,24.869404
+"Vaisalantie 8, Espoo",60.188772,24.808225
+"Rasinkatu 4, Vantaa",60.322319,25.064418
+"Huutokonttori, Helsinki",60.159741,24.92108
+"Kutomotie 16, Helsinki",60.215633,24.86967
+"Mekaanikonkatu 1, Helsinki",60.199873,25.042353
+"Jokiniemi, Vantaa",60.298265,25.056779
+"Pertunpellontie 1, Helsinki",60.268254,24.992128
+"Satulamaakarintie 1, Espoo",60.190294,24.619902
+"Siltasaarenkatu 13, Helsinki",60.181689,24.949918
+"Rautatieläisenkatu 1, Helsinki",60.202179,24.939039
+"Ristiaallokonkatu 4, Espoo",60.154028,24.642401
+"Kirkkojärventie 6, Espoo",60.205621,24.655357
+"Mäkelänkatu 54, Helsinki",60.196815,24.950508
+"Sakara 2, Helsinki",60.243729,25.079121
+"Neitsytsaarentie 1, Helsinki",60.222304,25.139937
+"Majurinkulma, Espoo",60.211559,24.825847
+"Vallikatu, Espoo",60.228212,24.81895
+"Keravan aurinkovoimala, Kerava",60.422788,25.125042
+"Vanha Viertotie 22, Helsinki",60.211793,24.880045
+"Vattuniemen Puistotie 1, Helsinki",60.151627,24.891596
+"Kiviteltankatu 1, Helsinki",60.229634,24.996369
+"Westendintie 99, Espoo",60.162875,24.791422
+"Erottajankatu, Helsinki",60.165423,24.944007
+"Kalevankatu, Helsinki",60.162834,24.92483
+"Hämeentie 67, Helsinki",60.194021,24.9645
+"Tammihaantie 2, Espoo",60.233487,24.718267
+"Huopalahdentie 10, Helsinki",60.198856,24.883189
+"Solnantie 19, Helsinki",60.195012,24.878169
+"Sauvatie, Vantaa",60.31977,25.073512
+"Sörnäisten rantatie 23, Helsinki",60.184963,24.965714
+"Säterintie 2, Helsinki",60.243172,24.993555
+"Töölönkatu 3, Helsinki",60.174019,24.931483
+"Fabianinkatu 1, Helsinki",60.163278,24.951227
+"Hernesaari, Helsinki",60.148743,25.098482
+"Järnvägstorget, Helsingfors",60.171283,24.942572
+"Asemakuja 3, Espoo",60.205033,24.660218
+"Katajaharjuntie 1, Helsinki",60.16405,24.859168
+"Tapanilankaari, Helsinki",60.267032,25.031848
+"Fabianinkatu 7, Helsinki",60.164216,24.950322
+"Gyldenintie 2, Helsinki",60.158518,24.876438
+"Helsinginkatu 20, Helsinki",60.186725,24.952057
+"Taivaskalliontie 1, Helsinki",60.219374,24.960202
+"Helsinki",60.172992,24.942044
+"Hämeentie 30, Helsinki",60.183581,24.95842
+"Postitalo, Helsinki",60.170971,24.937039
+"Itämerenkatu 8, Helsinki",60.1633,24.918027
+"Tähkätie 4, Helsinki",60.234461,24.850818
+"Leenankuja, Espoo",60.153628,24.741334
+"Kuusikkotie 4, Helsinki",60.230334,24.927302
+"Olympiakylä, 3061, Helsinki",60.210898,24.952538
+"Rasinkatu 15, Vantaa",60.3241,25.066468
+"Lummetie 5, Vantaa",60.296515,25.040502
+"Upseerinkatu 3, Espoo",60.216151,24.818655
+"Heinjoenpolku 2, Espoo",60.203414,24.802286
+"Lohkopellontie 1, Helsinki",60.224325,24.966214
+"Maununnevantie 3, Helsinki",60.243707,24.901524
+"Kuuluttajankatu 1, Helsinki",60.205584,24.916683
+"Komeetankatu 2, Espoo",60.166378,24.733955
+"Porvoonkatu 19, Helsinki",60.190915,24.946564
+"Kirstinkatu 4, Helsinki",60.186063,24.946434
+"Laivalahdenkaari 34, Helsinki",60.186243,25.032903
+"Piispansilta, Espoo",60.160398,24.73769
+"Unikkotie 3, Helsinki",60.245968,24.990782
+"Runeberginkatu 61, Helsinki",60.180343,24.925153
+"Ulvilantie 1, Helsinki",60.205373,24.879575
+"Adjutantinkatu 8, Espoo",60.223239,24.83458
+"Iivisniemenkatu 4, Espoo",60.149207,24.69051
+"Nihtisilta 4, Espoo",60.207219,24.749601
+"Tuukkalantie 15, Helsinki",60.242407,25.100841
+"Lehdeskuja 1, Espoo",60.182709,24.667741
+"Trumpettitie 6, Helsinki",60.238822,24.868381
+"Rautalammintie 1, Helsinki",60.196641,24.956129
+"Henttaa, Espoo",60.192543,24.730731
+"Junkkarinkaari 7, Vantaa",60.288801,24.961233
+"Leppävaarankatu 1, Espoo",60.217572,24.81273
+"Mannerheimintie 113, Helsinki",60.206637,24.899724
+"Ressun lukio, Helsinki",60.167059,24.938156
+"Satamaradankatu 5, Helsinki",60.190473,24.954583
+"Kaivokselantie 8, Vantaa",60.266991,24.871267
+"Suursuonlaita 2, Helsinki",60.234154,24.93611
+"Munkkiniemen Puistotie 17, Helsinki",60.198138,24.87822
+"Antaksentie 3, Vantaa",60.292633,24.945289
+"Äyritie 1, Vantaa",60.294477,24.976478
+"Erottajankatu 5, Helsinki",60.164715,24.944811
+"Valimotie, Helsinki",60.216789,24.877451
+"Näyttelijäntie 16, Helsinki",60.231597,24.896321
+"Isonniitynkuja 2, Espoo",60.163593,24.706804
+"Hiomotie 46, Helsinki",60.219599,24.869376
+"Maarukankuja 1, Vantaa",60.337781,25.103453
+"Raiviosuonmäki 3, Vantaa",60.280988,24.846336
+"Huokotie 1, Helsinki",60.261487,25.075828
+"Laivalahdenkaari 19, Helsinki",60.187126,25.035537
+"Kaivokatu 6, Helsinki",60.170036,24.942171
+"Hämeentie 34, Helsinki",60.184165,24.959069
+"Isonnevantie 1, Helsinki",60.210648,24.888746
+"Sahaajankatu 20, Helsinki",60.200056,25.046853
+"Soidinkuja 6, Helsinki",60.252876,25.017069
+"Otsolahdentie 16, Espoo",60.177535,24.818044
+"Mäkelänkatu 30, Helsinki",60.194441,24.956176
+"Toivonkatu, Helsinki",60.184195,24.924781
+"Nuumäki, E1401, Espoo",60.23675,24.74327
+"Töölön Yhteiskoulu, Helsinki",60.185282,24.923824
+"Olarinniityntie 4, Espoo",60.18063,24.735894
+"Viipurinkatu 4, Helsinki",60.190489,24.947421
+"Kielotie 7, Vantaa",60.290003,25.03626
+"Tehtaankatu, Helsinki",60.158196,24.94469
+"Vuorenpeikontie 5, Helsinki",60.201626,25.055871
+"Vanha Tapanilantie 62, Helsinki",60.262323,25.012774
+"Sokerilinnantie 11, Espoo",60.21555,24.815446
+"Kastanjakuja, Vantaa",60.256552,24.803895
+"Tietotie 2, Espoo",60.185374,24.822213
+"Yrjönkatu 18, Helsinki",60.165628,24.941726
+"Viljo Sohkasen Katu 3, Vantaa",60.29784,25.051244
+"Hämeentie 3, Helsinki",60.18072,24.952917
+"Honkavaarankuja 1, Espoo",60.230082,24.734993
+"Katajanokanranta 1, Helsinki",60.165377,24.972022
+"Miestentie 2, Espoo",60.179369,24.826884
+"Everstinkuja 1, Espoo",60.212762,24.822834
+"Kivivuorentie 4, Vantaa",60.278362,24.853924
+"Viulutie 1, Helsinki",60.236826,24.880577
+"Lokkalantie 14, Helsinki",60.199117,24.87987
+"Karhutie 1, Kirkkonummi",60.127201,24.471827
+"Kiskottajankuja 1, Espoo",60.22955,24.814117
+"Castréninkatu 28, Helsinki",60.185695,24.950533
+"Kaivopuisto, Helsinki",60.159617,24.95463
+"Kluuvikatu 3, Helsinki",60.168642,24.947847
+"Lontoonkatu 9, Helsinki",60.203073,24.973774
+"Teknobulevardi 1, Vantaa",60.305686,24.970866
+"Merituulentie 30, Espoo",60.170762,24.772125
+"Kuusitie 12, Helsinki",60.194131,24.898449
+"Kontulankaari 24, Helsinki",60.246296,25.080236
+"Ateneum, Helsinki",60.170018,24.944089
+"Pirkkolan Uimahalli, Helsinki",60.231977,24.910778
+"Vanamontie 4, Vantaa",60.307995,25.029677
+"Museokatu 10, Helsinki",60.174019,24.931483
+"Löydöstie 1, Vantaa",60.262694,24.857608
+"Sibeliuksenkatu 10, Helsinki",60.181958,24.922238
+"Porintie 5, Helsinki",60.205779,24.870164
+"Esikkotie 9, Vantaa",60.298559,25.043944
+"Lönnrotinkatu 41, Helsinki",60.162698,24.927221
+"Siilitie 18, Helsinki",60.212932,25.038669
+"Unioninkatu 20, Helsinki",60.165999,24.950571
+"Hakaniemenranta 1, Helsinki",60.177745,24.950993
+"Yläkiventie 5, Helsinki",60.222557,25.070881
+"Kaanaanpiha 4, Helsinki",60.212394,24.980689
+"Temppeliaukion kirkko, Helsinki",60.172953,24.925227
+"Helsinge skola, Vantaa",60.281924,24.981057
+"Vanha Viertotie 2, Helsinki",60.209149,24.888807
+"Haapaniemistigen 15, Kyrkslätt",60.234346,24.365658
+"Hämeentie 124, Helsinki",60.205114,24.96975
+"Karhulantie 2, Helsinki",60.215716,25.104714
+"Kasöörinkatu 3, Helsinki",60.198631,24.942528
+"Hakaniemenkatu 7, Helsinki",60.178971,24.954775
+"Kuitinmäen koulu, Espoo",60.168173,24.726736
+"Koivuvaarankuja 1, Vantaa",60.255316,24.817152
+"Teuvo Pakkalan Tie 2, Helsinki",60.227112,24.902929
+"Aleksis Kiven Katu 38, Helsinki",60.189935,24.950558
+"Liusketie 16, Helsinki",60.237195,25.01659
+"Eteläinen Hesperiankatu 22, Helsinki",60.176423,24.923255
+"Pasilan Puistotie 10, Helsinki",60.200027,24.923784
+"Konalantie 12, Helsinki",60.226828,24.85204
+"Kirvisenkuja 1, Vantaa",60.365669,25.069156
+"Ulvilantie 25, Helsinki",60.209483,24.87265
+"Helsingin medialukio, Helsinki",60.269825,25.030543
+"Maistraatinportti 4, Helsinki",60.198185,24.926011
+"Kruununhaka, Helsinki",60.173005,24.953536
+"Matinkartanontie 1, Espoo",60.15664,24.752658
+"Jupperin koulu, Espoo",60.249012,24.769721
+"Myllynkivenkuja 4, Vantaa",60.284616,24.837486
+"Katajanokanlaituri 6, Helsinki",60.165302,24.963664
+"Aamuruskontie 2, Helsinki",60.283712,25.028118
+"Opastinsilta 8, Helsinki",60.198971,24.939272
+"Hertaksentie 2, Vantaa",60.290616,25.041832
+"Mikkelä, Espoo",60.204998,24.635395
+"Vanha Turuntie 75, Espoo",60.220298,24.692154
+"Rastilantie 5, Helsinki",60.214278,25.131276
+"Pronssitie 4, Helsinki",60.231261,24.883609
+"Mannerheimintie 120, Helsinki",60.192271,24.909211
+"Peltokyläntie, Helsinki",60.268678,24.982448
+"Raikurinne 1, Vantaa",60.277398,24.863754
+"Kielotie 21, Vantaa",60.298415,25.041474
+"Betonimiehenkuja 3, Espoo",60.180546,24.831856
+"Korkeavuorenkatu 1, Helsinki",60.159586,24.947132
+"Nuijamäki 6, Espoo",60.210895,24.764078
+"Siemenkuja 3, Helsinki",60.254994,25.011555
+"Kuusisaari, Helsinki",60.185767,24.861868
+"Bemböle, Espoo",60.224645,24.680813
+"Aapelinkatu, Espoo",60.155153,24.75022
+"Palokunnanmäki 1, Vantaa",60.299487,25.035003
+"Takomotie 8, Helsinki",60.21786,24.873533
+"Gyldenintie 6, Helsinki",60.160334,24.877154
+"Väinölänkatu 17, Helsinki",60.213773,24.954594
+"Kirstinkatu 2, Helsinki",60.185577,24.946393
+"Keilaranta 10, Espoo",60.178655,24.834253
+"Kaitaan koulu ja lukio, Espoo",60.149483,24.696579
+"Hiihtäjäntie 1, Helsinki",60.194861,25.0284
+"Aleksis Kiven katu, Helsinki",60.195079,24.938804
+"Kauriintie 4, Helsinki",60.272397,24.991042
+"Hevostilantie 1, Espoo",60.270343,24.7557
+"Kutojantie 4, Espoo",60.211286,24.750026
+"Meriusva 5, Espoo",60.154713,24.636514
+"Kaivosvoudintie 4, Vantaa",60.265307,24.869261
+"Ukonkivenpolku 4, Vantaa",60.262,24.868066
+"Sepontie 1, Espoo",60.188206,24.790929
+"Maininkipuisto, Espoo",60.151956,24.646389
+"Bulevardi 28, Helsinki",60.163679,24.935972
+"Bulevardi 6, Helsinki",60.165691,24.942317
+"Fredrikinkatu 20, Helsinki",60.162696,24.938593
+"Tiedekeskus Heureka, Vantaa",60.287679,25.04021
+"Ilmalankatu 2, Helsinki",60.205584,24.916683
+"Jakomäentie, Helsinki",60.25535,25.069746
+"Albertinkatu 25, Helsinki",60.163818,24.934504
+"Leinikkitie 11, Vantaa",60.310453,25.033168
+"Piispanportti 12, Espoo",60.163912,24.735801
+"Porvoonkatu 14, Helsinki",60.19064,24.945048
+"Kuusitie 4, Helsinki",60.19491,24.900546
+"Myllymatkantie 4, Helsinki",60.224788,25.064394
+"Kumpulantie 1, Helsinki",60.19642,24.941259
+"Urheilupuistontie 3, Espoo",60.177784,24.785949
+"Rosendalinkuja 3, Vantaa",60.267621,24.966999
+"Salmisaarenranta 11, Helsinki",60.16623,24.899943
+"Finnoontie 12, Espoo",60.169932,24.690605
+"Eteläranta 8, Helsinki",60.164675,24.952095
+"Tilanhoitajankaari 8, Helsinki",60.231701,25.031208
+"Karakalliontie 5, Espoo",60.227462,24.764286
+"Keskuskatu 2, Helsinki",60.168616,24.942134
+"Sörnäistenkatu 19, Helsinki",60.194329,24.973429
+"Bulevardi 7, Helsinki",60.164972,24.938235
+"Myrskyläntie 22, Helsinki",60.224404,24.969586
+"Suutarila, Helsinki",60.283659,25.010861
+"Mankkaantie 2, Espoo",60.19413,24.768142
+"Teuvo Pakkalan Tie 1, Helsinki",60.227585,24.90326
+"Kanneltie 8, Helsinki",60.241196,24.878596
+"Junailijankuja 10, Helsinki",60.200452,24.936008
+"Keilaranta 13, Espoo",60.178052,24.836384
+"Tiedekeskus Heureka, Vantaa",60.287679,25.04021
+"Itämerenkatu 23, Helsinki",60.163454,24.906717
+"Kiviaidankatu 2, Helsinki",60.153845,24.88313
+"Kivipadontie 4, Helsinki",60.23191,24.948424
+"Airport Hotel Pilotti;Ravintola Volare, Vantaa",60.284674,24.965799
+"Elimäenkatu 5, Helsinki",60.193841,24.951613
+"Piispankalliontie 17, Espoo",60.168863,24.750639
+"Pitäjänmäentie 14, Helsinki",60.214903,24.875692
+"Liusketie 2, Helsinki",60.235564,25.013221
+"Kaarlenkatu 11, Helsinki",60.186015,24.952011
+"Pikku Satamakatu 2, Helsinki",60.165942,24.964381
+"Viikinkaari 4, Helsinki",60.226327,25.014755
+"Käpylänaukio 1, Helsinki",60.213374,24.943932
+"Puunhaltijankuja 1, Vantaa",60.323069,25.042696
+"Vanha Tapanilantie, Helsinki",60.261386,25.015923
+"Koivuvaarankuja 2, Vantaa",60.256229,24.814253
+"Takkatie 1, Helsinki",60.221812,24.861234
+"Viherlaaksonranta 7, Espoo",60.227757,24.730368
+"Leinelänkaari 14, Vantaa",60.324567,25.038857
+"Asentajankatu 6, Helsinki",60.198182,25.043374
+"Mäkelänkatu 13, Helsinki",60.192352,24.961645
+"Männikkötie 5, Helsinki",60.226045,24.929885
+"Masalan asema, Kirkkonummi",60.158645,24.53919
+"Haapaniemenkatu 5, Helsinki",60.181137,24.957907
+"Castréninkatu 3, Helsinki",60.184066,24.94564
+"Laajavuorenkuja 3, Vantaa",60.281109,24.8411
+"Mäkitorpantie 1, Helsinki",60.221632,24.948218
+"Petter Wetterin tie 1, Helsinki",60.192358,25.031349
+"Leppäsuonkatu 9, Helsinki",60.169429,24.922867
+"Ratatie 11, Vantaa",60.293002,25.044729
+"Nauriskaski, Espoo",60.172957,24.652785
+"Lehtovuorenkatu 6, Helsinki",60.249,24.833529
+"Sörnäisten Rantatie 22, Helsinki",60.186951,24.970241
+"Töölönkatu 55, Helsinki",60.184897,24.918896
+"Nervanderinkatu 13, Helsinki",60.173932,24.928784
+"Pirttikorpi 7, Espoo",60.171165,24.637243
+"Rajatorpantie 41, Vantaa",60.255316,24.817152
+"Harmotie 1, Vantaa",60.276696,25.100716
+"Savela, Helsinki",60.238316,24.986036
+"Eerikinkatu 27, Helsinki",60.165373,24.929413
+"Korppaanmäentie 1, Helsinki",60.203959,24.89856
+"Kotisaarenkatu 3, Helsinki",60.202382,24.969648
+"Hämeentie 6, Helsinki",60.180892,24.951807
+"Kasarmikatu 21, Helsinki",60.165862,24.94811
+"Helsinginkatu 21, Helsinki",60.18721,24.952658
+"Kuntatalo, Helsinki",60.183931,24.940627
+"Elimäenkatu 30, Helsinki",60.197463,24.947129
+"Leinikkitie 9, Vantaa",60.310415,25.034238
+"Martinkeskus, Vantaa",60.276645,24.847481
+"Leppävaaran stadion, Espoo",60.225827,24.799135
+"Hämeentie, Helsinki",60.198494,24.961933
+"Kiviteltankatu 3, Helsinki",60.228791,24.996439
+"Erik Palménin Aukio 1, Helsinki",60.203817,24.96079
+"Itämerenkatu 12, Helsinki",60.1632,24.916249
+"Itälahdenkatu 1, Helsinki",60.14758,24.882866
+"Mikkolantie 1, Helsinki",60.234234,24.975155
+"Maunulan Yhteiskoulu ja Helsingin matematiikkalukio, Helsinki",60.230034,24.924964
+"Mannerheimintie 79, Helsinki",60.193012,24.909488
+"Lummetie 1, Vantaa",60.296159,25.044396
+"Kauppakartanonkatu 16, Helsinki",60.207401,25.082383
+"Esterinportti 2, Helsinki",60.19695,24.928001
+"Otaranta 2, Espoo",60.183834,24.836668
+"Mannerheimintie 14, Helsinki",60.168401,24.939858
+"Mannerheimintie 3, Helsinki",60.169551,24.940994
+"Sturenkatu 37, Helsinki",60.195522,24.959449
+"Vanha Viertotie 21, Helsinki",60.211066,24.88455
+"Kivelän sairaala, Helsinki",60.180682,24.918235
+"Helsingin rautatieasema, Helsinki",60.171831,24.9412
+"Lautatarhankatu 6, Helsinki",60.189304,24.970835
+"Henrik Lättiläisen Katu 3, Helsinki",60.225084,24.987077
+"Rinnekoti, Espoo",60.35292,24.654663
+"Kaivokatu 10, Helsinki",60.169551,24.940994
+"Kauppamiehentie 1, Espoo",60.176593,24.801788
+"Takojankuja 3, Kerava",60.403119,25.140318
+"Purotie 8, Helsinki",60.215018,24.867688
+"Ramsaynkuja 1, Espoo",60.195333,24.589081
+"Intiankatu 1, Helsinki",60.20654,24.972567
+"Ratapihantie 1, Helsinki",60.197796,24.93733
+"Mäkelänkatu 50, Helsinki",60.196323,24.951837
+"Lammastie, Vantaa",60.260166,24.805211
+"Kalevankatu 1, Helsinki",60.168401,24.939858
+"Venäläinen koulu, 1948, Helsinki",60.237889,24.897051
+"Ryytimaa 1, Espoo",60.239967,24.71012
+"Pursimiehenkatu, Helsinki",60.159616,24.938459
+"Alakaupunki, E4034, Espoo",60.155289,24.631323
+"Siltakuja 1, Sipoo",60.366397,25.260643
+"Tuusulantaival 42, Kerava",60.408623,25.08317
+"Sörnäisten Rantatie 6, Helsinki",60.179463,24.954096
+"Pyhtäänkorvenkuja 6, Vantaa",60.300852,24.970437
+"Hiomotie 42, Helsinki",60.218944,24.869978
+"Dagmarinkatu 5, Helsinki",60.173555,24.929385
+"Fleminginkatu 23, Helsinki",60.188721,24.953339
+"Fleminginkatu 25, Helsinki",60.189259,24.953305
+"Haapaniemenrinne 1, Espoo",60.251571,24.724129
+"Töölöntullinkatu 1, Helsinki",60.189627,24.915259
+"Aleksis Kiven Katu 3, Helsinki",60.189727,24.957461
+"Kirstintie 30, Espoo",60.205473,24.672928
+"Itäportti 1, Espoo",60.175491,24.73742
+"Kirkkokatu 6, Helsinki",60.170835,24.957805
+"Porthaninkatu 15, Helsinki",60.183834,24.955068
+"Siilitie 7, Helsinki",60.210092,25.040372
+"Rörstrandinkatu, Helsinki",60.206102,24.978063
+"Porintie 1, Helsinki",60.203991,24.871273
+"Kylänvanhimmantie 29, Helsinki",60.228437,24.96372
+"Tyynenmerenkatu 3, Helsinki",60.158922,24.921242
+"Köydenpunojankatu 8, Helsinki",60.163579,24.923272
+"Vanha Turuntie 14, Kauniainen",60.221526,24.717943
+"Kala-Matti 1, Espoo",60.157937,24.737293
+"Katajaharju, Helsinki",60.168296,24.857289
+"Kangasalantie 13, Helsinki",60.197767,24.955752
+"Savelantie 3, Helsinki",60.24034,24.993349
+"Unioninkatu 37, Helsinki",60.173556,24.950785
+"Porttikuja 1, Espoo",60.199451,24.768321
+"Trillakatu 1, Espoo",60.217276,24.786229
+"Suezinkatu 3, Helsinki",60.158603,24.920379
+"Albertinkatu 1, Helsinki",60.159703,24.940799
+"Vilhonvuorenkatu 1, Helsinki",60.187593,24.963528
+"Simonkatu 9, Helsinki",60.169125,24.935
+"Takomotie 23, Helsinki",60.218489,24.872987
+"Viikintie 1, Helsinki",60.216375,24.981997
+"Kämnerintie 4, Helsinki",60.277457,25.027843
+"Varikkotie, Helsinki",60.208882,25.062809
+"Castréninkatu 18, Helsinki",60.185601,24.947347
+"Viljo Sohkasen Katu 3, Vantaa",60.29784,25.051244
+"Katajalaakso 1, Espoo",60.167526,24.625624
+"Kaadekuja 1, Helsinki",60.253901,25.074531
+"Kivikonkaari 14, Helsinki",60.238829,25.06763
+"Kivihaantie 1, Helsinki",60.209682,24.904312
+"Itämerenkatu 3, Helsinki",60.163956,24.91977
+"Liisankatu 16, Helsinki",60.173908,24.954387
+"Laajalahdentie 23, Helsinki",60.201696,24.878242
+"Helsingintie 10, Kauniainen",60.213169,24.7356
+"Kaupintie 14, Helsinki",60.230126,24.882328
+"Maapadontie 1, Helsinki",60.231585,24.94942
+"Maininkitie 9, Espoo",60.151864,24.64753
+"Kaarlenkatu 1, Helsinki",60.184468,24.951908
+"Mannerheimintie 91, Helsinki",60.19466,24.904621
+"Perkkaantie 3, Espoo",60.216763,24.821467
+"Melkonkatu 1, Helsinki",60.147554,24.885137
+"Koisotie 4, Vantaa",60.301184,25.016188
+"Leppävaaran stadion, Espoo",60.225827,24.799135
+"Sturenkatu 25, Helsinki",60.193471,24.955605
+"Poutamäentie 13, Helsinki",60.219315,24.852333
+"Myllypurontie, Helsinki",60.224873,25.059304
+"Myllypurontie 22, Helsinki",60.223903,25.061594
+"Rajamänty, E1501, Espoo",60.22565,24.74736
+"Otaniementie 9, Espoo",60.184755,24.827755
+"Brahenkatu, Helsinki",60.189768,24.94839
+"Olympiaranta 1, Helsinki",60.160764,24.958862
+"Aleksanterinkatu 9, Helsinki",60.169168,24.948192
+"Matinkatu 22, Espoo",60.157759,24.740027
+"Mikonkatu 8, Helsinki",60.169598,24.944632
+"Maistraatinkatu 1, Helsinki",60.197973,24.923949
+"Minnesstensstigen 1, Helsingfors",60.236575,25.021324
+"Sorolantien leikkialue, Helsinki",60.25369,24.876406
+"Mätästie 1, Helsinki",60.262997,25.079348
+"Eteläranta 1, Helsinki",60.163776,24.952468
+"Erkki Melartinin Tie 1, Helsinki",60.246488,24.989467
+"Docksgatan, Helsingfors",60.158471,24.934135
+"Tunnelitie, Kauniainen",60.212053,24.728824
+"Museokatu 1, Helsinki",60.174939,24.931732
+"Keilalahdentie 4, Espoo",60.170162,24.828502
+"Lintulahdenkuja 4, Helsinki",60.183229,24.961273
+"Työpajankatu 13, Helsinki",60.188174,24.973899
+"Ratakatu, Helsinki",60.162826,24.943309
+"Antti Korpin Tie 1, Helsinki",60.218009,24.96666
+"Kaasutehtaankatu 1, Helsinki",60.186696,24.974134
+"Hankasuontie 11, Helsinki",60.249193,24.840321
+"Katajanokan terminaali, Helsinki",60.16426,24.969331
+"Ratamestarinkatu 11, Helsinki",60.201224,24.93946
+"Helsinginkatu 13, Helsinki",60.18751,24.955759
+"Joupinpuisto 1, Espoo",60.201966,24.680918
+"Tammasaarenkatu 1, Helsinki",60.161071,24.903751
+"Unikkotie 5, Vantaa",60.292541,25.039039
+"Piilipuuntie 31, Espoo",60.189427,24.738661
+"Kuuluttajankatu 2, Helsinki",60.204807,24.91814
+"Runeberginkatu 43, Helsinki",60.175938,24.922672
+"Viherkalliontie 7, Espoo",60.228399,24.747444
+"Anjankuja 3, Espoo",60.157255,24.739936
+"Haaga, Helsinki",60.222458,24.905532
+"Niittyportti 4, Espoo",60.169612,24.769986
+"Pohjoinen Hesperiankatu 15, Helsinki",60.177692,24.924509
+"Pasilan asema, Helsinki",60.199228,24.933114
+"Lumikintie 3, Helsinki",60.203789,25.058198
+"Hakaniemenranta 6, Helsinki",60.178422,24.955331
+"Talin keilahalli, Helsinki",60.210315,24.878877
+"Malminkatu 3, Helsinki",60.168204,24.926658
+"Hansatie 4, Espoo",60.186795,24.589834
+"Hämeentie 85, Helsinki",60.196424,24.963071
+"Puistomäki 1, Espoo",60.216715,24.788144
+"Karhunkierros 4, Vantaa",60.260385,24.810759
+"Elimäenkatu 1, Helsinki",60.193487,24.953132
+"Radiokatu 11, Helsinki",60.202923,24.920569
+"Kokkokalliontie 3, Helsinki",60.228824,24.851585
+"Kauniala, Kauniainen",60.218542,24.701444
+"Kivalterintie 20, Helsinki",60.229949,24.952285
+"Leppälinnunrinne 6, Espoo",60.230128,24.781858
+"Vaakatie 6, Helsinki",60.230205,24.875984
+"Fredrikinkatu 12, Helsinki",60.160908,24.941445
+"Mannerheimintie 40, Helsinki",60.177142,24.929538
+"Hiekkaharjun asema, Vantaa",60.303175,25.049125
+"Maasälväntie 5, Nurmijärvi",60.362158,24.728589
+"Otaniementie, Espoo",60.18015,24.834483
+"Harustie 7, Helsinki",60.203507,25.121586
+"Friisilä, Espoo",60.166243,24.719322
+"Kuunkatu, Espoo",60.172322,24.722822
+"Kipparlahden silmukka, Helsinki",60.192017,25.019554
+"Pyyntitie 1, Espoo",60.158267,24.734496
+"Adolf Lindforsin tie, Helsinki",60.229132,24.893596
+"Mechelininkatu, Helsinki",60.173492,24.919133
+"Svanströminkuja 1, Helsinki",60.167507,25.043793
+"Nauvontie 18, Helsinki",60.207601,24.900529
+"Kanneltie 2, Helsinki",60.240597,24.883874
+"Pasilanraitio 10, Helsinki",60.200564,24.924183
+"Katajanokanlaituri 8, Helsinki",60.163838,24.96835
+"Televisiokatu 4, Helsinki",60.204326,24.924703
+"Miestentie 1, Espoo",60.178232,24.828168
+"Seltterikuja 4, Helsinki",60.238024,24.848435
+"Hämeentie 32, Helsinki",60.183863,24.958691
+"Tuulikuja 2, Espoo",60.170598,24.801576
+"Energiakuja 3, Helsinki",60.166671,24.902258
+"Ukonvaaja 1, Espoo",60.18546,24.792159
+"Keilasatama 5, Espoo",60.1728,24.829951
+"Laajasuontie 35, Helsinki",60.220257,24.894321
+"Laaksotie 20, Vantaa",60.321167,25.010719
+"Lapinlahdenkatu 16, Helsinki",60.167202,24.922881
+"Lönnrotinkatu 1, Helsinki",60.167549,24.941083
+"Kylmäojantie, Vantaa",60.32075,25.01585
+"Haukilahdensolmu, Espoo",60.167484,24.772868
+"Unioninkatu 45, Helsinki",60.175374,24.951051
+"Vellamonkatu 1, Helsinki",60.193102,24.966072
+"Mannerheimintie, Helsinki",60.187696,24.918749
+"Snellmaninkatu, Helsinki",60.173956,24.95235
+"Porslahdentie 24, Helsinki",60.213291,25.149238
+"Laajasuontie 31, Helsinki",60.21988,24.897144
+"Herttoniemen sairaala, Helsinki",60.207444,25.036071
+"Atomitie 5, Helsinki",60.222465,24.872242
+"Untamontie 1, Helsinki",60.209937,24.948191
+"Sähkötie 5, Vantaa",60.277384,24.975273
+"Pääskylänrinne 3, Helsinki",60.187927,24.965924
+"Ruoholahdenkatu 21, Helsinki",60.164586,24.923876
+"Otto Brandtin Tie 16, Helsinki",60.233136,24.978492
+"Käskynhaltijantie 5, Helsinki",60.23704,24.972453
+"Untamontie 9, Helsinki",60.211184,24.951542
+"Leppälinnunrinne, Espoo",60.229247,24.782926
+"Kyllikinportti, Helsinki",60.199837,24.925613
+"Klariksentie 1, Espoo",60.18436,24.740236
+"Kasarmikatu 4, Helsinki",60.160015,24.947574
+"Lehtikallio 4, Vantaa",60.2551,24.812774
+"Käpyläntie 2, Helsinki",60.21407,24.95759
+"Maistraatinportti 2, Helsinki",60.198339,24.927228
+"Koskelantie 5, Helsinki",60.207976,24.946851
+"Neljäs Linja 2, Helsinki",60.181669,24.953832
+"Riistavuorenkuja 4, Helsinki",60.218077,24.885452
+"Kielotie 13, Vantaa",60.294127,25.03936
+"Sturenkatu 22, Helsinki",60.193849,24.954463

--- a/gen_requests.py
+++ b/gen_requests.py
@@ -3,40 +3,39 @@
 import itertools
 import simplejson
 
-TEST_ALL_MODES = False #set to True to make it a hard test with short walk limits and walk-only trips &c.
+TEST_ALL_MODES = True #set to True to make it a hard test with short walk limits and walk-only trips &c.
 
 json_out = {}
-    
+
 # Initialize the otpprofiler DB 'requests' table with query parameters.
 # Note that on-street modes are not walk-limited, so we don't want to vary the max walk param there.
 # another way to do this would be to store the various values in tables, and construct this
 # view as a constrained product of all the other tables (probably eliminating the synthetic keys).
 
 # (time, arriveBy)
-times = [ ("08:50:00", True ),
+times = [ ("08:50:00", False ),
           ("14:00:00", True ),
           ("18:00:00", False),
-          ("23:45:00", False) ]
+          ("23:45:00", True) ]
 
 if TEST_ALL_MODES:
     # (mode, walk, min)
-    modes = [ (mode, walk, "QUICK") 
-        for mode in ["WALK,TRANSIT", "BICYCLE,TRANSIT"] 
-        for walk in [250, 2000, 40000] ]
+    modes = [ ("WALK,TRANSIT", 2000, "QUICK") ]
+    modes.append( ("BICYCLE,TRANSIT", 20000, "QUICK") )
     modes.append( ("WALK", 2000, "QUICK") )
-    modes.extend( [("BICYCLE", 2000, minimize) for minimize in ["QUICK", "SAFE", "FLAT"]] )
+    modes.append( ("BICYCLE", 2000, "SAFE") )
 else:
     # (mode, walk, min)
     modes = [ ("WALK,TRANSIT", 2000, "QUICK") ]
 
-all_params = [(time, walk, mode, minimize, arriveBy) 
-    for (time, arriveBy) in times 
-    for (mode, walk, minimize) in modes] 
+all_params = [(time, walk, mode, minimize, arriveBy)
+    for (time, arriveBy) in times
+    for (mode, walk, minimize) in modes]
 
 requests_json = []
 for i, params in enumerate( all_params ) :
-    # NOTE the use of double quotes to force case-sensitivity for column names. These columns 
-    # represent query parameters that will be substituted directly into URLs, and URLs are defined 
+    # NOTE the use of double quotes to force case-sensitivity for column names. These columns
+    # represent query parameters that will be substituted directly into URLs, and URLs are defined
     # to be case-sensitive.
 
     time,maxWalkDist,mode,min,arriveBy = params
@@ -48,7 +47,7 @@ json_out['requests'] = requests_json
 # Initialize the otpprofiler DB with random endpoints and user-defined endpoints
 import csv
 endpoints_json = []
-for filename, random in [("endpoints_custom.csv", False), ("endpoints_random.csv", True)] :
+for filename, random in [("endpoints_custom_hsl.csv", False)] :
     endpoints = open(filename)
     reader = csv.DictReader(endpoints)
 
@@ -62,4 +61,3 @@ json_out['endpoints'] = endpoints_json
 fpout = open("requests.json","w")
 simplejson.dump(json_out, fpout, indent=2 )
 fpout.close()
-

--- a/hreport.py
+++ b/hreport.py
@@ -17,14 +17,12 @@ def main(filenames):
     border-collapse: collapse;
 }
 th, td {
-    text-align: left;    
+    text-align: left;
 }</style></head>"""
 
 	datasets = []
-	shas = []
 	for fn in filenames:
 		blob = json.load( open(fn) )
-		shas.append( blob['git_sha1'] )
 		dataset = dict( [(response["id_tuple"], response) for response in blob['responses']] )
 		datasets.append( dataset )
 
@@ -35,11 +33,6 @@ th, td {
 	dataset_total_times = dict(zip( range(len(datasets)),[[] for x in range(len(datasets))]) )
 	dataset_avg_times = dict(zip(range(len(datasets)),[[] for x in range(len(datasets))]) )
 	dataset_fails = dict(zip(range(len(datasets)), [0]*len(datasets)))
-
-	yield "<tr><td>request id</td>"
-	for fn,sha in zip(filenames,shas):
-		yield "<td>%s (commit:%s)</td>"%(fn,sha)
-	yield "</tr>"
 
 	for id_tuple in id_tuples:
 		yield """<tr><td rowspan="2"><a href="%s">%s</a></td>"""%(datasets[0][id_tuple]['url'], id_tuple)

--- a/hreport.py
+++ b/hreport.py
@@ -28,6 +28,10 @@ th, td {
 
 	id_tuples = datasets[0].keys()
 
+        if len(id_tuples)==0:
+                print "Input does not contain any data"
+                exit()
+
 	yield """<table border="1">"""
 
 	dataset_total_times = dict(zip( range(len(datasets)),[[] for x in range(len(datasets))]) )

--- a/hreport.py
+++ b/hreport.py
@@ -11,15 +11,6 @@ def main(filenames):
 	if len(filenames)==0:
 		return
 
-	yield "<html>"
-	yield """<head><style>table, th, td {
-    border: 1px solid black;
-    border-collapse: collapse;
-}
-th, td {
-    text-align: left;
-}</style></head>"""
-
 	datasets = []
 	for fn in filenames:
 		blob = json.load( open(fn) )
@@ -31,6 +22,15 @@ th, td {
         if len(id_tuples)==0:
                 print "Input does not contain any data"
                 exit()
+
+	yield "<html>"
+	yield """<head><style>table, th, td {
+    border: 1px solid black;
+    border-collapse: collapse;
+}
+th, td {
+    text-align: left;
+}</style></head>"""
 
 	yield """<table border="1">"""
 

--- a/otpprofiler.py
+++ b/otpprofiler.py
@@ -10,7 +10,7 @@ from copy import copy
 # python-requests wraps urllib2 providing a much nicer API.
 import grequests
 
-DATE = '2014-12-30'
+DATE = '2015-12-30'
 # split out base and specific endpoint
 SHOW_PARAMS = False
 SHOW_URL = False
@@ -119,7 +119,7 @@ def summarize_plan (itinerary) :
             waits.append(wait)
     ret = {
         'start_time' : time.asctime(time.gmtime(itinerary['startTime'] / 1000)) + ' GMT',
-        'duration' : '%d msec' % int(itinerary['duration']),
+        'duration' : '%d sec' % int(itinerary['duration']),
         'n_legs' : n_legs,
         'n_vehicles' : n_vehicles,
         'walk_distance' : itinerary['walkDistance'],

--- a/otpprofiler.py
+++ b/otpprofiler.py
@@ -273,6 +273,7 @@ def response_callback_factory(row, profile) :
 
         if SHOW_RESPONSE :
             pp.pprint(row)
+        response.connection.close();
     # return the function definition, a closure for a specific instance of 'row'
     return handle_response
 

--- a/otpprofiler.py
+++ b/otpprofiler.py
@@ -10,7 +10,7 @@ from copy import copy
 # python-requests wraps urllib2 providing a much nicer API.
 import grequests
 
-DATE = '2014-12-30'
+DATE = '2016-09-20'
 # split out base and specific endpoint
 SHOW_PARAMS = False
 SHOW_URL = False
@@ -63,10 +63,10 @@ def get_params(fast):
 def getServerInfo(host):
     """Get information about the server that is being profiled. Returns a tuple of:
     (sha1, version, cpuName, nCores)
-    where sha1 is the hash of the HEAD commit, version is the output of 'git describe' (which 
-    includes the last tag and how many commits have been made on top of that tag), 
+    where sha1 is the hash of the HEAD commit, version is the output of 'git describe' (which
+    includes the last tag and how many commits have been made on top of that tag),
     cpuName is the model of the cpu as reported by /proc/cpuinfo via the OTP serverinfo API,
-    and nCores is the number of (logical) cores reported by that same API, including hyperthreading. 
+    and nCores is the number of (logical) cores reported by that same API, including hyperthreading.
     """
     url_meta = "http://"+host+"/otp/"
 
@@ -285,21 +285,21 @@ def run(connect_args) :
     host = connect_args.pop('host')
     profile = connect_args.pop('profile')
     print("profile=%s"%profile)
-    info = getServerInfo(host)
-    while retry > 0 and info == None:
-        print "Failed to connect to OTP server. Waiting to retry (%d)." % retry
-        time.sleep(10)
-        info = getServerInfo(host)
-        retry -= 1
-
-    if info == None :
-        print "Failed to identify OTP version. Exiting."
-        exit(-2)
+    # info = getServerInfo(host)
+    # while retry > 0 and info == None:
+    #     print "Failed to connect to OTP server. Waiting to retry (%d)." % retry
+    #     time.sleep(10)
+    #     info = getServerInfo(host)
+    #     retry -= 1
+    #
+    # if info == None :
+    #     print "Failed to identify OTP version. Exiting."
+    #     exit(-2)
 
     # Create a dict describing this particular run of the profiler, which will be output as JSON
     run_time_id = int(time.time())
-    run_row = info + (notes, run_time_id)
-    run_json = dict(zip(('git_sha1','git_describe','cpu_name','cpu_cores','notes','id'), run_row))
+    run_row = (notes, run_time_id)
+    run_json = dict(zip(('notes','id'), run_row))
 
     all_params = get_params(fast)
     random.shuffle(all_params)
@@ -325,7 +325,7 @@ def run(connect_args) :
             params['numItineraries'] = 3
 
         qstring = urllib.urlencode(params)
-        url = "http://%s/otp/routers/default/%s?%s"%(host, api_method, qstring)
+        url = "http://%s/routing/v1/routers/hsl/%s?%s"%(host, api_method, qstring)
 
         # Tomcat server + spaces in URLs -> HTTP 505 confusion
         if SHOW_PARAMS :
@@ -374,5 +374,3 @@ if __name__=="__main__":
     # args is a non-iterable, non-mapping Namespace (allowing usage in the form args.name),
     # so convert it to a dict before passing it into the run function.
     run(vars(args))
-
-

--- a/otpprofiler.py
+++ b/otpprofiler.py
@@ -13,6 +13,8 @@ from random import randint, seed
 # python-requests wraps urllib2 providing a much nicer API.
 import grequests
 
+TIME='14:00:00'
+
 # generate test date on a recent/upcoming monday. Use a fixed work day to keep results comparable
 cdate = date.today()
 dd = cdate.day - cdate.weekday() # monday = 0. want monday!
@@ -20,8 +22,6 @@ if dd < 1:
     dd = dd + 7 # use next monday
 
 DATE = "%s-%s-%s"%(cdate.year, cdate.month, dd)
-
-print "TEST DATE:", DATE
 
 # split out base and specific endpoint
 SHOW_PARAMS = False
@@ -331,6 +331,11 @@ def run(connect_args) :
     count = connect_args.pop('count')
     host = connect_args.pop('host')
     profile = connect_args.pop('profile')
+    Date = connect_args.pop('date')
+    Time = connect_args.pop('time')
+
+    print "TEST DATE:", Date, Time
+
     print("profile=%s"%profile)
     # info = getServerInfo(host)
     # while retry > 0 and info == None:
@@ -349,7 +354,6 @@ def run(connect_args) :
     run_json = dict(zip(('notes','id'), run_row))
 
     all_params = get_params(fast, count)
-    random.shuffle(all_params)
     global t0, N # HACK
     t0 = time.time()
     N = len(all_params)
@@ -360,7 +364,8 @@ def run(connect_args) :
         oid = params.pop('oid')
         tid = params.pop('tid')
 
-        params['date'] = DATE
+        params['date'] = Date
+        params['time'] = Time
         if profile:
             api_method = 'profile'
             params['from'] = params.pop('fromPlace')
@@ -369,7 +374,7 @@ def run(connect_args) :
             params['limit'] = 3
         else:
             api_method = 'plan'
-            params['numItineraries'] = 3
+            params['numItineraries'] = 1
 
         qstring = urllib.urlencode(params)
 
@@ -427,6 +432,8 @@ if __name__=="__main__":
     parser.add_argument('host')
     parser.add_argument('-f', '--fast', action='store_true', default=False)
     parser.add_argument('-n', '--notes')
+    parser.add_argument('-d', '--date', default=DATE)
+    parser.add_argument('-t', '--time', default='14:00')
     parser.add_argument('-r', '--retry', type=int, default=5)
     parser.add_argument('-c', '--count', type=int, default=1100)
     parser.add_argument('-p', '--profile', action='store_true', default=False)

--- a/result_plot_from_file.py
+++ b/result_plot_from_file.py
@@ -1,0 +1,25 @@
+import json, violin
+
+def plot_results(dataset, label):
+
+    data = []
+    total_times = []
+
+    if "responses" in dataset:
+        for resp in dataset['responses']:
+            if "total_time" in resp:
+                total_times.append( float(resp["total_time"][:-5]) / 1000.00) #to seconds
+
+        data.append(total_times)
+        violin.violin_plot(data, bp=True, scale=True, labels=[label])
+
+
+if __name__=='__main__':
+    import sys
+
+    if len(sys.argv)<3:
+        print "usage: cmd json_summary_file_name plot_label"
+        exit()
+
+    dataset = json.load(open(sys.argv[1]))
+    plot_results(dataset, sys.argv[2])


### PR DESCRIPTION
- Fix test time so that it is easy to repeat comparable routing tests (previously used current time)
- Add d=yyyy-mm-dd and t=hh:mm params to otpprofiler.py. Exact routing test time can be set easily.
